### PR TITLE
Debug Railway deployment issues

### DIFF
--- a/backend/app/api/v1/endpoints/monetization_discovery.py
+++ b/backend/app/api/v1/endpoints/monetization_discovery.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from loguru import logger
 
 from app.core.database import get_async_session
-from app.core.auth import get_current_user
+from app.core.security import get_current_user
 from app.models.user import User
 from app.models.monetization import (
     CreatorProfile, ActiveProject, ContentAnalysis,


### PR DESCRIPTION
Fixed ModuleNotFoundError by changing import from non-existent app.core.auth to app.core.security where get_current_user is actually defined.

Resolves Railway deployment crash on startup.