### PR TITLE
Debug recurring Railway deployment issues

### DIFF
--- a/backend/app/services/content_analyzer.py
+++ b/backend/app/services/content_analyzer.py
@@ -11,8 +11,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, desc
 from loguru import logger
 
-from app.models.youtube_models import YouTubeVideo, YouTubeComment
-from app.models.instagram_models import InstagramPost, InstagramComment
+from app.models.youtube import YouTubeVideo, YouTubeComment
+from app.models.instagram import InstagramPost, InstagramComment
 from app.models.monetization import ContentAnalysis, CreatorProfile
 
 


### PR DESCRIPTION
Fix ModuleNotFoundError by correcting imports:
- youtube_models -> youtube
- instagram_models -> instagram

This resolves the Railway deployment crash loop.