### PR TITLE
Enable multiple active monetization projects

### DIFF
--- a/backend/alembic/versions/20251109_2340_remove_one_project_per_user_constraint.py
+++ b/backend/alembic/versions/20251109_2340_remove_one_project_per_user_constraint.py
@@ -1,0 +1,26 @@
+"""remove one_project_per_user constraint for multi-project support
+
+Revision ID: 20251109_2340
+Revises: 20251109_2330
+Create Date: 2025-11-09 23:40:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '20251109_2340'
+down_revision = '20251109_2330'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Remove the unique constraint that limits users to one project
+    op.drop_constraint('one_project_per_user', 'active_projects', type_='unique')
+
+
+def downgrade() -> None:
+    # Re-add the unique constraint
+    op.create_unique_constraint('one_project_per_user', 'active_projects', ['user_id'])

--- a/backend/app/models/monetization.py
+++ b/backend/app/models/monetization.py
@@ -75,13 +75,12 @@ class ActiveProject(Base):
     customized_plan = Column(JSONB, nullable=False)  # copy of opportunity template
     
     # Relationships
-    user = relationship("User", back_populates="active_project")
+    user = relationship("User", back_populates="active_projects")
     chat_messages = relationship("ProjectChatMessage", back_populates="project", cascade="all, delete-orphan")
     task_completions = relationship("ProjectTaskCompletion", back_populates="project", cascade="all, delete-orphan")
     decisions = relationship("ProjectDecision", back_populates="project", cascade="all, delete-orphan")
-    
+
     __table_args__ = (
-        UniqueConstraint("user_id", name="one_project_per_user"),
         CheckConstraint("status IN ('active', 'completed', 'abandoned')", name="valid_status"),
         CheckConstraint("overall_progress >= 0 AND overall_progress <= 100", name="valid_overall_progress"),
         CheckConstraint("planning_progress >= 0 AND planning_progress <= 100", name="valid_planning_progress"),

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -158,7 +158,7 @@ class User(Base):
     background_jobs = relationship("BackgroundJob", back_populates="user", cascade="all, delete-orphan")
     sessions = relationship("UserSession", back_populates="user", cascade="all, delete-orphan")
     creator_profile = relationship("CreatorProfile", back_populates="user", uselist=False, cascade="all, delete-orphan")
-    active_project = relationship("ActiveProject", back_populates="user", uselist=False, cascade="all, delete-orphan")
+    active_projects = relationship("ActiveProject", back_populates="user", cascade="all, delete-orphan")
 
     def __repr__(self) -> str:
         return f"<User(email='{self.email}')>"

--- a/frontend/app/(dashboard)/monetization/page.tsx
+++ b/frontend/app/(dashboard)/monetization/page.tsx
@@ -6,13 +6,13 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { Loader2, Sparkles, ArrowRight, Plus, TrendingUp } from 'lucide-react';
-import { getProfile, getActiveProject, createProject, CreatorProfile, ActiveProject } from '@/lib/monetization-api';
+import { getProfile, getAllProjects, createProject, CreatorProfile, ActiveProject } from '@/lib/monetization-api';
 import { ErrorHandler } from '@/lib/error-handler';
 
 export default function MonetizationPage() {
   const router = useRouter();
   const [profile, setProfile] = useState<CreatorProfile | null>(null);
-  const [project, setProject] = useState<ActiveProject | null>(null);
+  const [projects, setProjects] = useState<ActiveProject[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isCreatingProject, setIsCreatingProject] = useState(false);
 
@@ -24,12 +24,12 @@ export default function MonetizationPage() {
     setIsLoading(true);
     const result = await ErrorHandler.withErrorHandling(
       async () => {
-        const [profileData, projectData] = await Promise.all([
+        const [profileData, projectsData] = await Promise.all([
           getProfile(),
-          getActiveProject()
+          getAllProjects()
         ]);
         setProfile(profileData);
-        setProject(projectData);
+        setProjects(projectsData.projects);
         return true;
       },
       'Loading monetization data'
@@ -90,51 +90,73 @@ export default function MonetizationPage() {
     );
   }
 
-  // Has profile but no project
-  if (!project) {
-    return (
-      <div className="container mx-auto p-6 space-y-6">
-        {/* Header */}
+  // Has profile - show projects list
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight text-primary-dark">
             Monetization Engine
           </h1>
           <p className="text-secondary-dark mt-2">
-            Launch your Premium Community with AI-powered guidance
+            {projects.length === 0
+              ? 'Launch your Premium Community with AI-powered guidance'
+              : `Managing ${projects.length} ${projects.length === 1 ? 'project' : 'projects'}`}
           </p>
         </div>
+        <Button
+          onClick={handleCreateProject}
+          disabled={isCreatingProject}
+          size="lg"
+        >
+          {isCreatingProject ? (
+            <>
+              <Loader2 className="h-5 w-5 mr-2 animate-spin" />
+              Creating...
+            </>
+          ) : (
+            <>
+              <Plus className="h-5 w-5 mr-2" />
+              New Project
+            </>
+          )}
+        </Button>
+      </div>
 
-        {/* Profile Summary */}
-        <div className="dashboard-card p-6 bg-gradient-to-r from-purple-50 to-blue-50 dark:from-purple-950/20 dark:to-blue-950/20 border-2 border-purple-200 dark:border-purple-800">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-lg font-semibold text-primary-dark mb-2">Your Creator Profile</h3>
-              <div className="flex items-center gap-4 text-sm text-secondary-dark">
-                <div className="flex items-center gap-2">
-                  <TrendingUp className="h-4 w-4" />
-                  <span className="capitalize">{profile.primary_platform}</span>
-                </div>
-                <div>
-                  {profile.follower_count.toLocaleString()} followers
-                </div>
-                <div>
-                  {profile.engagement_rate}% engagement
-                </div>
-                <div className="capitalize">
-                  {profile.niche}
-                </div>
+      {/* Profile Summary */}
+      <div className="dashboard-card p-6 bg-gradient-to-r from-purple-50 to-blue-50 dark:from-purple-950/20 dark:to-blue-950/20 border-2 border-purple-200 dark:border-purple-800">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-primary-dark mb-2">Your Creator Profile</h3>
+            <div className="flex items-center gap-4 text-sm text-secondary-dark">
+              <div className="flex items-center gap-2">
+                <TrendingUp className="h-4 w-4" />
+                <span className="capitalize">{profile.primary_platform}</span>
+              </div>
+              <div>
+                {profile.follower_count.toLocaleString()} followers
+              </div>
+              <div>
+                {profile.engagement_rate}% engagement
+              </div>
+              <div className="capitalize">
+                {profile.niche}
               </div>
             </div>
-            <Button
-              variant="outline"
-              onClick={() => router.push('/monetization/setup')}
-            >
-              Edit Profile
-            </Button>
           </div>
+          <Button
+            variant="outline"
+            onClick={() => router.push('/monetization/setup')}
+          >
+            Edit Profile
+          </Button>
         </div>
+      </div>
 
-        {/* Premium Community Opportunity */}
+      {/* Projects List */}
+      {projects.length === 0 ? (
+        // No projects - show opportunity card
         <div className="dashboard-card p-8 space-y-6">
           <div className="flex items-start gap-6">
             <div className="text-6xl">💎</div>
@@ -143,7 +165,7 @@ export default function MonetizationPage() {
                 Premium Community Launch
               </h2>
               <p className="text-secondary-dark mb-4">
-                Turn your engaged audience into a thriving paid community. Launch a Discord or Circle 
+                Turn your engaged audience into a thriving paid community. Launch a Discord or Circle
                 membership in 3-5 weeks with personalized AI guidance.
               </p>
 
@@ -204,89 +226,83 @@ export default function MonetizationPage() {
                 ) : (
                   <>
                     <Plus className="h-5 w-5 mr-2" />
-                    Start Your Project
+                    Start Your First Project
                   </>
                 )}
               </Button>
             </div>
           </div>
         </div>
-      </div>
-    );
-  }
-
-  // Has active project - show summary and link
-  return (
-    <div className="container mx-auto p-6 space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight text-primary-dark">
-          Monetization Engine
-        </h1>
-        <p className="text-secondary-dark mt-2">
-          Your Premium Community launch is in progress
-        </p>
-      </div>
-
-      {/* Active Project Card */}
-      <div className="dashboard-card p-8 space-y-6 bg-gradient-to-br from-purple-50 to-blue-50 dark:from-purple-950/20 dark:to-blue-950/20 border-2 border-purple-200 dark:border-purple-800">
-        <div className="flex items-start justify-between">
-          <div className="flex items-start gap-4">
-            <div className="text-5xl">💎</div>
-            <div>
-              <h2 className="text-2xl font-bold text-primary-dark mb-2">
-                {project.opportunity_title}
-              </h2>
-              <div className="flex items-center gap-3 text-sm text-secondary-dark">
-                <Badge
-                  variant="secondary"
-                  className="bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+      ) : (
+        // Has projects - show grid
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {projects.map((project) => (
+            <div
+              key={project.id}
+              className="dashboard-card p-6 space-y-4 hover:shadow-lg transition-shadow cursor-pointer"
+              onClick={() => router.push(`/monetization/project/${project.id}`)}
+            >
+              <div className="flex items-start justify-between">
+                <div className="flex items-start gap-3">
+                  <div className="text-4xl">💎</div>
+                  <div>
+                    <h3 className="text-xl font-bold text-primary-dark mb-1">
+                      {project.opportunity_title}
+                    </h3>
+                    <div className="flex items-center gap-2 text-sm text-secondary-dark">
+                      <Badge
+                        variant="secondary"
+                        className={
+                          project.status === 'active'
+                            ? 'bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300'
+                            : project.status === 'completed'
+                            ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300'
+                            : 'bg-gray-100 text-gray-700 dark:bg-gray-950 dark:text-gray-300'
+                        }
+                      >
+                        {project.status}
+                      </Badge>
+                      <span>•</span>
+                      <span>Started {new Date(project.started_at).toLocaleDateString()}</span>
+                    </div>
+                  </div>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    router.push(`/monetization/project/${project.id}`);
+                  }}
                 >
-                  {project.status}
-                </Badge>
-                <span>Started {new Date(project.started_at).toLocaleDateString()}</span>
-                <span>•</span>
-                <span>{project.message_count} messages</span>
+                  <ArrowRight className="h-4 w-4" />
+                </Button>
+              </div>
+
+              {/* Progress Bars */}
+              <div className="space-y-3">
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-xs font-medium text-secondary-dark">Overall Progress</span>
+                    <span className="text-sm font-bold text-purple-600 dark:text-purple-400">
+                      {project.overall_progress}%
+                    </span>
+                  </div>
+                  <Progress value={project.overall_progress} className="h-1.5" />
+                </div>
+                <div className="grid grid-cols-2 gap-3 text-xs text-secondary-dark">
+                  <div>Planning: {project.planning_progress}%</div>
+                  <div>Execution: {project.execution_progress}%</div>
+                </div>
+              </div>
+
+              <div className="text-xs text-secondary-dark">
+                Last updated {new Date(project.last_activity_at).toLocaleDateString()}
               </div>
             </div>
-          </div>
-          <Button onClick={() => router.push(`/monetization/project/${project.id}`)}>
-            Open Project
-            <ArrowRight className="h-4 w-4 ml-2" />
-          </Button>
+          ))}
         </div>
-
-        {/* Progress Summary */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div className="p-4 bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-sm font-medium text-secondary-dark">Overall Progress</span>
-              <span className="text-lg font-bold text-purple-600 dark:text-purple-400">
-                {project.overall_progress}%
-              </span>
-            </div>
-            <Progress value={project.overall_progress} className="h-2" />
-          </div>
-          <div className="p-4 bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-sm font-medium text-secondary-dark">Decisions Made</span>
-              <span className="text-lg font-bold text-blue-600 dark:text-blue-400">
-                {project.decisions.length}/5
-              </span>
-            </div>
-            <Progress value={(project.decisions.length / 5) * 100} className="h-2" />
-          </div>
-          <div className="p-4 bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-sm font-medium text-secondary-dark">Tasks Completed</span>
-              <span className="text-lg font-bold text-emerald-600 dark:text-emerald-400">
-                {project.completed_tasks.length}/22
-              </span>
-            </div>
-            <Progress value={(project.completed_tasks.length / 22) * 100} className="h-2" />
-          </div>
-        </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/frontend/app/(dashboard)/monetization/project/[id]/page.tsx
+++ b/frontend/app/(dashboard)/monetization/project/[id]/page.tsx
@@ -12,7 +12,7 @@ import { TaskList } from '@/components/monetization/TaskList';
 import { DecisionCards } from '@/components/monetization/DecisionCards';
 import { ProjectWorkspaceSkeleton } from '@/components/monetization/Skeletons';
 import {
-  getActiveProject,
+  getProjectById,
   getProjectMessages,
   sendMessage,
   parseSSEStream,
@@ -46,7 +46,7 @@ export default function ProjectWorkspacePage() {
       setError(null);
 
       const [projectData, messagesData] = await Promise.all([
-        getActiveProject(),
+        getProjectById(projectId),
         getProjectMessages(projectId)
       ]);
 

--- a/frontend/lib/monetization-api.ts
+++ b/frontend/lib/monetization-api.ts
@@ -165,6 +165,38 @@ export async function createProject(): Promise<{ project_id: string; redirect_ur
   return response.json();
 }
 
+export async function getAllProjects(status?: 'active' | 'completed' | 'abandoned'): Promise<{ projects: ActiveProject[]; total: number }> {
+  const url = status
+    ? `${API_BASE}/monetization/projects?status=${status}`
+    : `${API_BASE}/monetization/projects`;
+
+  const response = await fetch(url, {
+    headers: await getAuthHeaders()
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch projects');
+  }
+
+  return response.json();
+}
+
+export async function getProjectById(projectId: string): Promise<ActiveProject | null> {
+  const response = await fetch(`${API_BASE}/monetization/projects/${projectId}`, {
+    headers: await getAuthHeaders()
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch project');
+  }
+
+  return response.json();
+}
+
 export async function getActiveProject(): Promise<ActiveProject | null> {
   const response = await fetch(`${API_BASE}/monetization/projects/active`, {
     headers: await getAuthHeaders()
@@ -176,6 +208,20 @@ export async function getActiveProject(): Promise<ActiveProject | null> {
 
   if (!response.ok) {
     throw new Error('Failed to fetch project');
+  }
+
+  return response.json();
+}
+
+export async function deleteProject(projectId: string): Promise<{ success: boolean; message: string }> {
+  const response = await fetch(`${API_BASE}/monetization/projects/${projectId}`, {
+    method: 'DELETE',
+    headers: await getAuthHeaders()
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.detail || 'Failed to delete project');
   }
 
   return response.json();


### PR DESCRIPTION
This commit enables users to create and manage multiple monetization projects simultaneously, removing the previous one-project-per-user limitation.

Backend Changes:
- Remove UNIQUE constraint on active_projects.user_id via database migration
- Update User model relationship from uselist=False to uselist=True
- Remove ActiveProject model unique constraint
- Add GET /monetization/projects endpoint to list all projects
- Add GET /monetization/projects/{id} endpoint to get specific project
- Add DELETE /monetization/projects/{id} endpoint to delete project
- Update POST /monetization/projects to allow multiple projects
- Update GET /monetization/projects/active to return most recent active project
- Update DELETE /monetization/profile/reset to delete all projects

Frontend Changes:
- Add getAllProjects(), getProjectById(), and deleteProject() API functions
- Update monetization dashboard to show all projects in a grid layout
- Add "New Project" button to create additional projects
- Update project workspace to use getProjectById instead of getActiveProject
- Display project status badges (active, completed, abandoned)
- Show progress bars for each project in the list

Migration:
- 20251109_2340_remove_one_project_per_user_constraint.py