### PR TITLE
Test early access signup feature

### DIFF
--- a/frontend/app/(auth)/onboarding/agency-application/page.tsx
+++ b/frontend/app/(auth)/onboarding/agency-application/page.tsx
@@ -80,7 +80,7 @@ const REFERRAL_SOURCES = [
 
 export default function AgencyApplicationPage() {
   const router = useRouter();
-  const { user, checkAuth } = useAuth();
+  const { user } = useAuth();
   const [step, setStep] = useState(1);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [newCreatorEmail, setNewCreatorEmail] = useState('');
@@ -218,8 +218,9 @@ export default function AgencyApplicationPage() {
       // Send formData directly - backend expects AgencyApplicationData schema
       await api.post('/onboarding/agency-application', formData);
 
-      // Refresh user state to get updated application_submitted_at
-      await checkAuth();
+      // Note: No need to call checkAuth() here - the backend updates the user state,
+      // and the pending page will fetch the latest status when it mounts.
+      // Calling checkAuth() here was causing loading issues during navigation.
 
       pushToast('Application submitted successfully!', 'success');
       router.push('/onboarding/pending');

--- a/frontend/app/(auth)/onboarding/creator-application/page.tsx
+++ b/frontend/app/(auth)/onboarding/creator-application/page.tsx
@@ -63,7 +63,7 @@ const REFERRAL_SOURCES = [
 
 export default function CreatorApplicationPage() {
   const router = useRouter();
-  const { user, checkAuth } = useAuth();
+  const { user } = useAuth();
   const [step, setStep] = useState(1);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formData, setFormData] = useState<FormData>({
@@ -146,8 +146,9 @@ export default function CreatorApplicationPage() {
       // Send formData directly - backend expects CreatorApplicationData schema
       await api.post('/onboarding/creator-application', formData);
 
-      // Refresh user state to get updated application_submitted_at
-      await checkAuth();
+      // Note: No need to call checkAuth() here - the backend updates the user state,
+      // and the pending page will fetch the latest status when it mounts.
+      // Calling checkAuth() here was causing loading issues during navigation.
 
       pushToast('Application submitted successfully!', 'success');
       router.push('/onboarding/pending');

--- a/frontend/app/(auth)/onboarding/pending/page.tsx
+++ b/frontend/app/(auth)/onboarding/pending/page.tsx
@@ -22,7 +22,7 @@ interface OnboardingStatus {
 
 export default function PendingPage() {
   const router = useRouter();
-  const { user, logout, checkAuth } = useAuth();
+  const { user, logout } = useAuth();
   const [status, setStatus] = useState<OnboardingStatus | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -34,7 +34,8 @@ export default function PendingPage() {
 
         // If approved, redirect to dashboard
         if (response.data.approval_status === 'approved') {
-          await checkAuth();
+          // Note: No need to call checkAuth() here - the dashboard will handle auth check on mount.
+          // Calling checkAuth() was causing potential loading delays during navigation.
           router.push('/dashboard');
         }
         // If rejected, redirect to rejected page
@@ -53,7 +54,7 @@ export default function PendingPage() {
     // Poll every 30 seconds to check for status updates
     const interval = setInterval(fetchStatus, 30000);
     return () => clearInterval(interval);
-  }, [router, checkAuth]);
+  }, [router]);
 
   const formatDate = (dateString: string | null) => {
     if (!dateString) return '';

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -18,6 +18,7 @@ export const api = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  timeout: 15000, // 15 second timeout to prevent hanging requests
 });
 
 // Add auth interceptor


### PR DESCRIPTION
…bmission

This fixes an issue where users would get stuck on an eternal loading screen after submitting their early access application (creator or agency).

Root cause:
- After submitting an application, the code called checkAuth() to refresh user state
- checkAuth() sets isLoading=true in the auth store while making an API call to /auth/me
- The onboarding layout shows a loading screen while isLoading=true
- If the /auth/me API call was slow or hung (no timeout configured), users got stuck

Changes:
1. Added 15-second timeout to axios instance to prevent hanging requests
2. Removed unnecessary checkAuth() calls after application submission
   - The backend already updates user state when application is submitted
   - The pending page fetches its own status when it mounts
   - This eliminates the loading state issue during navigation
3. Removed checkAuth() call from pending page approval redirect
   - Dashboard will handle auth check on mount
4. Cleaned up unused checkAuth imports

This ensures smooth navigation to the pending page after application submission.