### PR TITLE
Restrict demo access to specific users

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -207,6 +207,13 @@ class Settings(BaseSettings):
     DEMO_SERVICE_URL: Optional[str] = None
     DEMO_WEBHOOK_SECRET: Optional[str] = None
 
+    # Demo Mode Access Control - emails allowed to use demo mode
+    DEMO_ALLOWED_EMAILS: List[str] = [
+        "caleb.a.trainer@gmail.com",
+        "caleb.trainer@thelaunchloop.com",
+        "petercollier100@gmail.com"
+    ]
+
     # Monitoring
     SENTRY_DSN: Optional[str] = None
 

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -26,6 +26,7 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
   const [demoMode, setDemoMode] = useState<boolean>(false);
   const [demoProfile, setDemoProfile] = useState<any>(null);
+  const [hasDemoAccess, setHasDemoAccess] = useState<boolean>(true);
 
   useEffect(() => {
     const fetchMetrics = async () => {
@@ -49,6 +50,7 @@ export default function DashboardPage() {
           const data = await response.json();
           setDemoMode(data.status === 'enabled');
           setDemoProfile(data.profile || null);
+          setHasDemoAccess(data.has_access ?? true); // Default to true if not provided
         }
       } catch (error) {
         console.error('Failed to fetch demo status:', error);
@@ -70,7 +72,7 @@ export default function DashboardPage() {
   return (
     <div className="space-y-10 animate-slide-up px-4 md:px-0"> {/* Add horizontal padding on mobile */}
       {/* Demo Mode Banner - Retro Styled */}
-      {demoMode && (
+      {hasDemoAccess && demoMode && (
         <div className="glass-panel rounded-2xl border border-holo-purple/30 p-6 shadow-glow-purple backdrop-blur-md">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
@@ -96,7 +98,7 @@ export default function DashboardPage() {
       )}
 
       {/* Demo Mode Enabling Banner */}
-      {!demoMode && demoProfile?.status === 'enabling' && (
+      {hasDemoAccess && !demoMode && demoProfile?.status === 'enabling' && (
         <div className="glass-panel rounded-2xl border border-yellow-500/30 p-6 shadow-glow-yellow backdrop-blur-md">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
@@ -122,7 +124,7 @@ export default function DashboardPage() {
       )}
 
       {/* Onboarding: Enable Demo Mode - Retro Styled */}
-      {!demoMode && !loading && (metrics?.interactions_today || 0) === 0 && (
+      {hasDemoAccess && !demoMode && !loading && (metrics?.interactions_today || 0) === 0 && (
         <div className="glass-panel rounded-2xl border border-holo-teal/30 p-6 shadow-glow-teal backdrop-blur-md">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">

--- a/frontend/app/(dashboard)/settings/demo-mode/page.tsx
+++ b/frontend/app/(dashboard)/settings/demo-mode/page.tsx
@@ -259,6 +259,32 @@ export default function DemoModePage() {
     );
   }
 
+  // Check if user has access to demo mode
+  if (demoStatus.has_access === false) {
+    return (
+      <div className="p-6 max-w-4xl mx-auto space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold text-primary-dark">Demo Mode</h1>
+          <p className="text-secondary-dark mt-1">
+            Test Repruv with simulated platform connections and AI-generated interactions
+          </p>
+        </div>
+
+        <Card className="border-yellow-500">
+          <CardHeader>
+            <CardTitle>Access Restricted</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-secondary-dark">
+              Demo mode is not currently available for your account.
+              Please contact support if you need access to demo functionality.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
   return (
     <div className="p-6 max-w-4xl mx-auto space-y-6">
       <div>

--- a/frontend/components/demo/DemoBanner.tsx
+++ b/frontend/components/demo/DemoBanner.tsx
@@ -17,9 +17,15 @@ interface DemoBannerProps {
     ig_followers: number;
   };
   error?: string;
+  hasAccess?: boolean;
 }
 
-export function DemoBanner({ status, profile, error }: DemoBannerProps) {
+export function DemoBanner({ status, profile, error, hasAccess }: DemoBannerProps) {
+  // Don't show banner if user doesn't have access to demo mode
+  if (hasAccess === false) {
+    return null;
+  }
+
   // Enabled state
   if (status === 'enabled') {
     return (


### PR DESCRIPTION
Added access control to limit demo mode functionality to an allowed list of email addresses. This ensures only authorized users can enable and use demo mode features.

Backend changes:
- Added DEMO_ALLOWED_EMAILS list to config with three authorized emails
- Created check_demo_access() helper function to verify user permissions
- Protected all demo endpoints (/enable, /disable, /seed-content) with access checks
- Added has_access flag to /demo/status response for frontend consumption
- Returns 403 Forbidden error with clear message for unauthorized access attempts

Frontend changes:
- Updated demo mode settings page to show access denied message for unauthorized users
- Modified settings page to hide Demo Mode tab for users without access
- Updated dashboard to hide demo mode banners and onboarding for unauthorized users
- Added hasAccess prop to DemoBanner component to prevent rendering for unauthorized users

Authorized emails:
- caleb.a.trainer@gmail.com
- caleb.trainer@thelaunchloop.com
- petercollier100@gmail.com