### PR TITLE
feat: add agency dashboard system for creator management

### DIFF
--- a/backend/alembic/versions/20251128_1200_add_agency_tables.py
+++ b/backend/alembic/versions/20251128_1200_add_agency_tables.py
@@ -1,0 +1,220 @@
+"""add agency tables for talent management
+
+Revision ID: 20251128_1200
+Revises: 20251117_1800
+Create Date: 2025-11-28 12:00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20251128_1200"
+down_revision = "20251117_1800"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create agency tables and related infrastructure."""
+
+    # Create ENUM types using DO blocks for idempotency
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE agency_member_role_enum AS ENUM ('owner', 'admin', 'member');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE agency_member_status_enum AS ENUM ('pending_invite', 'pending_request', 'active', 'removed');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE agency_invitation_status_enum AS ENUM ('pending', 'accepted', 'expired', 'cancelled');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE agency_opportunity_status_enum AS ENUM ('draft', 'sent', 'viewed', 'accepted', 'declined', 'completed', 'cancelled');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    # Create agencies table
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS agencies (
+            id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            name VARCHAR(255) NOT NULL,
+            slug VARCHAR(255) UNIQUE NOT NULL,
+            owner_id UUID NOT NULL,
+            logo_url VARCHAR(500),
+            website VARCHAR(500),
+            description TEXT,
+            settings JSONB NOT NULL DEFAULT '{}',
+            is_active BOOLEAN NOT NULL DEFAULT true,
+            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            CONSTRAINT fk_agencies_owner_id FOREIGN KEY (owner_id) REFERENCES users(id)
+        )
+    """)
+
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agencies_slug ON agencies (slug)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agencies_owner_id ON agencies (owner_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agencies_is_active ON agencies (is_active)")
+
+    # Create agency_members table
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS agency_members (
+            id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            agency_id UUID NOT NULL,
+            user_id UUID NOT NULL,
+            role agency_member_role_enum NOT NULL DEFAULT 'member',
+            status agency_member_status_enum NOT NULL DEFAULT 'pending_invite',
+            invited_by UUID,
+            invited_at TIMESTAMP WITH TIME ZONE,
+            joined_at TIMESTAMP WITH TIME ZONE,
+            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            CONSTRAINT fk_agency_members_agency_id FOREIGN KEY (agency_id) REFERENCES agencies(id) ON DELETE CASCADE,
+            CONSTRAINT fk_agency_members_user_id FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            CONSTRAINT fk_agency_members_invited_by FOREIGN KEY (invited_by) REFERENCES users(id),
+            CONSTRAINT uq_agency_members_agency_user UNIQUE (agency_id, user_id)
+        )
+    """)
+
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agency_members_agency_id ON agency_members (agency_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agency_members_user_id ON agency_members (user_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agency_members_status ON agency_members (status)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agency_members_role ON agency_members (role)")
+
+    # Create agency_invitations table
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS agency_invitations (
+            id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            agency_id UUID NOT NULL,
+            email VARCHAR(255) NOT NULL,
+            token VARCHAR(255) UNIQUE NOT NULL,
+            invited_by UUID NOT NULL,
+            expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+            accepted_at TIMESTAMP WITH TIME ZONE,
+            status agency_invitation_status_enum NOT NULL DEFAULT 'pending',
+            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            CONSTRAINT fk_agency_invitations_agency_id FOREIGN KEY (agency_id) REFERENCES agencies(id) ON DELETE CASCADE,
+            CONSTRAINT fk_agency_invitations_invited_by FOREIGN KEY (invited_by) REFERENCES users(id)
+        )
+    """)
+
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agency_invitations_agency_id ON agency_invitations (agency_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agency_invitations_email ON agency_invitations (email)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agency_invitations_token ON agency_invitations (token)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agency_invitations_status ON agency_invitations (status)")
+
+    # Create agency_opportunities table
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS agency_opportunities (
+            id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            agency_id UUID NOT NULL,
+            creator_id UUID NOT NULL,
+            created_by UUID NOT NULL,
+
+            title VARCHAR(255) NOT NULL,
+            brand_name VARCHAR(255) NOT NULL,
+            brand_logo_url VARCHAR(500),
+            description TEXT NOT NULL,
+
+            requirements JSONB NOT NULL DEFAULT '{}',
+            compensation JSONB NOT NULL DEFAULT '{}',
+
+            deadline TIMESTAMP WITH TIME ZONE,
+            content_deadline TIMESTAMP WITH TIME ZONE,
+
+            status agency_opportunity_status_enum NOT NULL DEFAULT 'draft',
+            sent_at TIMESTAMP WITH TIME ZONE,
+            viewed_at TIMESTAMP WITH TIME ZONE,
+            creator_response_at TIMESTAMP WITH TIME ZONE,
+            creator_notes TEXT,
+
+            project_id UUID,
+
+            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+            CONSTRAINT fk_agency_opportunities_agency_id FOREIGN KEY (agency_id) REFERENCES agencies(id) ON DELETE CASCADE,
+            CONSTRAINT fk_agency_opportunities_creator_id FOREIGN KEY (creator_id) REFERENCES users(id),
+            CONSTRAINT fk_agency_opportunities_created_by FOREIGN KEY (created_by) REFERENCES users(id),
+            CONSTRAINT fk_agency_opportunities_project_id FOREIGN KEY (project_id) REFERENCES active_projects(id) ON DELETE SET NULL
+        )
+    """)
+
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agency_opportunities_agency_id ON agency_opportunities (agency_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agency_opportunities_creator_id ON agency_opportunities (creator_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agency_opportunities_status ON agency_opportunities (status)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agency_opportunities_created_by ON agency_opportunities (created_by)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agency_opportunities_sent_at ON agency_opportunities (sent_at)")
+
+    # Add agency_id column to users table
+    op.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS agency_id UUID")
+    op.execute("""
+        DO $$ BEGIN
+            ALTER TABLE users ADD CONSTRAINT fk_users_agency_id
+                FOREIGN KEY (agency_id) REFERENCES agencies(id);
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+    op.execute("CREATE INDEX IF NOT EXISTS idx_users_agency_id ON users (agency_id)")
+
+
+def downgrade() -> None:
+    """Remove agency tables and related infrastructure."""
+
+    # Drop index and column from users
+    op.execute("DROP INDEX IF EXISTS idx_users_agency_id")
+    op.execute("ALTER TABLE users DROP CONSTRAINT IF EXISTS fk_users_agency_id")
+    op.execute("ALTER TABLE users DROP COLUMN IF EXISTS agency_id")
+
+    # Drop agency_opportunities table
+    op.execute("DROP INDEX IF EXISTS idx_agency_opportunities_sent_at")
+    op.execute("DROP INDEX IF EXISTS idx_agency_opportunities_created_by")
+    op.execute("DROP INDEX IF EXISTS idx_agency_opportunities_status")
+    op.execute("DROP INDEX IF EXISTS idx_agency_opportunities_creator_id")
+    op.execute("DROP INDEX IF EXISTS idx_agency_opportunities_agency_id")
+    op.execute("DROP TABLE IF EXISTS agency_opportunities")
+
+    # Drop agency_invitations table
+    op.execute("DROP INDEX IF EXISTS idx_agency_invitations_status")
+    op.execute("DROP INDEX IF EXISTS idx_agency_invitations_token")
+    op.execute("DROP INDEX IF EXISTS idx_agency_invitations_email")
+    op.execute("DROP INDEX IF EXISTS idx_agency_invitations_agency_id")
+    op.execute("DROP TABLE IF EXISTS agency_invitations")
+
+    # Drop agency_members table
+    op.execute("DROP INDEX IF EXISTS idx_agency_members_role")
+    op.execute("DROP INDEX IF EXISTS idx_agency_members_status")
+    op.execute("DROP INDEX IF EXISTS idx_agency_members_user_id")
+    op.execute("DROP INDEX IF EXISTS idx_agency_members_agency_id")
+    op.execute("DROP TABLE IF EXISTS agency_members")
+
+    # Drop agencies table
+    op.execute("DROP INDEX IF EXISTS idx_agencies_is_active")
+    op.execute("DROP INDEX IF EXISTS idx_agencies_owner_id")
+    op.execute("DROP INDEX IF EXISTS idx_agencies_slug")
+    op.execute("DROP TABLE IF EXISTS agencies")
+
+    # Drop ENUM types
+    op.execute("DROP TYPE IF EXISTS agency_opportunity_status_enum")
+    op.execute("DROP TYPE IF EXISTS agency_invitation_status_enum")
+    op.execute("DROP TYPE IF EXISTS agency_member_status_enum")
+    op.execute("DROP TYPE IF EXISTS agency_member_role_enum")

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -47,6 +47,8 @@ from app.api.v1.endpoints import marketing_admin
 from app.api.v1.endpoints import interactions, views, fans
 # Demo mode endpoints
 from app.api.v1.endpoints import demo, demo_webhooks, analytics, jobs
+# Agency endpoints
+from app.api.v1.endpoints import agency_auth, agency, creator_agency, agency_opportunities, creator_opportunities
 
 # Create the main API router
 api_router = APIRouter()
@@ -306,6 +308,37 @@ api_router.include_router(
 api_router.include_router(
     monetization_discovery.router,
     tags=["monetization", "discovery"],
+)
+
+# Agency endpoints
+api_router.include_router(
+    agency_auth.router,
+    prefix="/agency",
+    tags=["agency", "authentication"],
+)
+
+api_router.include_router(
+    agency.router,
+    prefix="/agency",
+    tags=["agency"],
+)
+
+api_router.include_router(
+    creator_agency.router,
+    prefix="/creator/agency",
+    tags=["creator", "agency"],
+)
+
+api_router.include_router(
+    agency_opportunities.router,
+    prefix="/agency/opportunities",
+    tags=["agency", "opportunities"],
+)
+
+api_router.include_router(
+    creator_opportunities.router,
+    prefix="/creator/opportunities",
+    tags=["creator", "opportunities"],
 )
 
 

--- a/backend/app/api/v1/endpoints/agency.py
+++ b/backend/app/api/v1/endpoints/agency.py
@@ -1,0 +1,730 @@
+"""
+Agency management endpoints.
+
+Handles agency operations, creator management, team members, and invitations.
+"""
+
+from datetime import datetime
+from typing import Any, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_async_session
+from app.core.security import get_current_user
+from app.models.user import User
+from app.schemas.agency import (
+    AgencyResponse,
+    AgencyUpdate,
+    AgencyMemberResponse,
+    AgencyMemberListResponse,
+    AgencyMemberRoleUpdate,
+    AgencyInviteRequest,
+    AgencyInvitationResponse,
+    AgencyInvitationListResponse,
+    AgencyPublicResponse,
+    CreatorAgencyResponse,
+    PendingInvitationResponse,
+)
+from app.services.agency_service import AgencyService
+from app.tasks.email import send_creator_invitation_email, send_join_request_notification
+
+router = APIRouter()
+
+
+# ============================================
+# Helper Functions
+# ============================================
+
+async def get_agency_service(db: AsyncSession = Depends(get_async_session)) -> AgencyService:
+    """Get agency service instance."""
+    return AgencyService(db)
+
+
+async def require_agency_user(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    """Require that the current user is an agency user."""
+    if current_user.account_type != "agency":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Agency account required",
+        )
+    return current_user
+
+
+async def get_user_agency_id(
+    current_user: User = Depends(require_agency_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> UUID:
+    """Get the agency ID for the current agency user."""
+    membership = await agency_service.get_user_agency_membership(current_user.id)
+    if not membership:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No agency found for user",
+        )
+    return membership.agency_id
+
+
+async def require_agency_admin(
+    current_user: User = Depends(require_agency_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> tuple[User, UUID]:
+    """Require that the current user is an agency admin (owner or admin role)."""
+    membership = await agency_service.get_user_agency_membership(current_user.id)
+    if not membership:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No agency found for user",
+        )
+
+    if membership.role not in ["owner", "admin"]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required",
+        )
+
+    return current_user, membership.agency_id
+
+
+# ============================================
+# Agency Profile Endpoints
+# ============================================
+
+@router.get("/me", response_model=AgencyResponse)
+async def get_my_agency(
+    agency_id: UUID = Depends(get_user_agency_id),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> Any:
+    """
+    Get the current user's agency profile.
+    """
+    agency = await agency_service.get_by_id(agency_id)
+    if not agency:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Agency not found",
+        )
+    return agency
+
+
+@router.patch("/me", response_model=AgencyResponse)
+async def update_my_agency(
+    updates: AgencyUpdate,
+    admin_data: tuple = Depends(require_agency_admin),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> Any:
+    """
+    Update the current user's agency profile.
+    Requires admin privileges.
+    """
+    _, agency_id = admin_data
+
+    agency = await agency_service.update_agency(
+        agency_id=agency_id,
+        **updates.model_dump(exclude_unset=True),
+    )
+
+    if not agency:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Agency not found",
+        )
+
+    return agency
+
+
+# ============================================
+# Creator Management Endpoints
+# ============================================
+
+@router.get("/creators", response_model=List[dict])
+async def list_agency_creators(
+    agency_id: UUID = Depends(get_user_agency_id),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> Any:
+    """
+    List all creators linked to the agency.
+    """
+    creators = await agency_service.get_agency_creators(agency_id)
+
+    return [
+        {
+            "id": creator.id,
+            "email": creator.email,
+            "full_name": creator.full_name,
+            "avatar_url": getattr(creator, 'avatar_url', None),
+            "youtube_channel_name": getattr(creator, 'youtube_channel_name', None),
+            "youtube_subscriber_count": getattr(creator, 'youtube_subscriber_count', None),
+            "created_at": creator.created_at,
+        }
+        for creator in creators
+    ]
+
+
+@router.delete("/creators/{creator_id}")
+async def remove_creator_from_agency(
+    creator_id: UUID,
+    admin_data: tuple = Depends(require_agency_admin),
+    agency_service: AgencyService = Depends(get_agency_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Remove a creator from the agency.
+    Requires admin privileges.
+    """
+    _, agency_id = admin_data
+
+    # Verify creator belongs to this agency
+    creator = await db.get(User, creator_id)
+    if not creator or creator.agency_id != agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Creator not found in agency",
+        )
+
+    success = await agency_service.unlink_creator_from_agency(creator_id)
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to remove creator",
+        )
+
+    return {"message": "Creator removed from agency"}
+
+
+# ============================================
+# Creator Invitation Endpoints
+# ============================================
+
+@router.post("/invitations", response_model=AgencyInvitationResponse, status_code=status.HTTP_201_CREATED)
+async def invite_creator(
+    invite_data: AgencyInviteRequest,
+    admin_data: tuple = Depends(require_agency_admin),
+    agency_service: AgencyService = Depends(get_agency_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Invite a creator to join the agency by email.
+    Requires admin privileges.
+    """
+    current_user, agency_id = admin_data
+
+    # Check if email already has a pending invitation
+    existing_invitations = await agency_service.get_agency_invitations(agency_id, status="pending")
+    for inv in existing_invitations:
+        if inv.email.lower() == invite_data.email.lower():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="An invitation has already been sent to this email",
+            )
+
+    # Check if user already exists and is already in an agency
+    from app.services.user import UserService
+    user_service = UserService(db)
+    existing_user = await user_service.get_by_email(invite_data.email)
+
+    if existing_user:
+        if existing_user.agency_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="This user is already part of an agency",
+            )
+        if existing_user.account_type != "creator":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Can only invite creator accounts",
+            )
+
+    # Create invitation
+    invitation = await agency_service.create_invitation(
+        agency_id=agency_id,
+        email=invite_data.email,
+        invited_by=current_user.id,
+    )
+
+    # Get agency for email
+    agency = await agency_service.get_by_id(agency_id)
+
+    # Send invitation email
+    try:
+        send_creator_invitation_email.delay(
+            email=invite_data.email,
+            agency_name=agency.name,
+            invitation_token=invitation.token,
+            inviter_name=current_user.full_name,
+        )
+    except Exception as e:
+        logger.error(f"Failed to queue invitation email: {e}")
+
+    return AgencyInvitationResponse(
+        id=invitation.id,
+        agency_id=invitation.agency_id,
+        email=invitation.email,
+        status=invitation.status,
+        invited_by=invitation.invited_by,
+        expires_at=invitation.expires_at,
+        accepted_at=invitation.accepted_at,
+        created_at=invitation.created_at,
+        agency_name=agency.name,
+        agency_logo_url=agency.logo_url,
+    )
+
+
+@router.get("/invitations", response_model=List[AgencyInvitationListResponse])
+async def list_invitations(
+    invitation_status: Optional[str] = Query(None, alias="status"),
+    agency_id: UUID = Depends(get_user_agency_id),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> Any:
+    """
+    List all invitations for the agency.
+    """
+    invitations = await agency_service.get_agency_invitations(agency_id, status=invitation_status)
+
+    return [
+        AgencyInvitationListResponse(
+            id=inv.id,
+            email=inv.email,
+            status=inv.status,
+            expires_at=inv.expires_at,
+            created_at=inv.created_at,
+        )
+        for inv in invitations
+    ]
+
+
+@router.delete("/invitations/{invitation_id}")
+async def cancel_invitation(
+    invitation_id: UUID,
+    admin_data: tuple = Depends(require_agency_admin),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> Any:
+    """
+    Cancel a pending invitation.
+    Requires admin privileges.
+    """
+    _, agency_id = admin_data
+
+    # Verify invitation belongs to this agency
+    invitation = await agency_service.get_invitation_by_id(invitation_id)
+    if not invitation or invitation.agency_id != agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Invitation not found",
+        )
+
+    success = await agency_service.cancel_invitation(invitation_id)
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot cancel this invitation",
+        )
+
+    return {"message": "Invitation cancelled"}
+
+
+# ============================================
+# Join Request Endpoints (Agency Side)
+# ============================================
+
+@router.get("/join-requests", response_model=List[AgencyMemberListResponse])
+async def list_join_requests(
+    agency_id: UUID = Depends(get_user_agency_id),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> Any:
+    """
+    List all pending join requests for the agency.
+    """
+    requests = await agency_service.get_pending_join_requests(agency_id)
+
+    return [
+        AgencyMemberListResponse(
+            id=req.id,
+            user_id=req.user_id,
+            role=req.role,
+            status=req.status,
+            user_email=req.user.email if req.user else "",
+            user_full_name=req.user.full_name if req.user else None,
+            joined_at=req.joined_at,
+        )
+        for req in requests
+    ]
+
+
+@router.post("/join-requests/{member_id}/accept")
+async def accept_join_request(
+    member_id: UUID,
+    admin_data: tuple = Depends(require_agency_admin),
+    agency_service: AgencyService = Depends(get_agency_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Accept a creator's join request.
+    Requires admin privileges.
+    """
+    _, agency_id = admin_data
+
+    # Get the member request
+    from sqlalchemy import select
+    from app.models.agency import AgencyMember
+
+    result = await db.execute(
+        select(AgencyMember).where(AgencyMember.id == member_id)
+    )
+    member = result.scalar_one_or_none()
+
+    if not member or member.agency_id != agency_id or member.status != "pending_request":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Join request not found",
+        )
+
+    # Accept the request (this also links the creator)
+    updated_member = await agency_service.accept_join_request(member_id)
+    if not updated_member:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to accept join request",
+        )
+
+    return {"message": "Join request accepted"}
+
+
+@router.post("/join-requests/{member_id}/reject")
+async def reject_join_request(
+    member_id: UUID,
+    admin_data: tuple = Depends(require_agency_admin),
+    agency_service: AgencyService = Depends(get_agency_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Reject a creator's join request.
+    Requires admin privileges.
+    """
+    _, agency_id = admin_data
+
+    # Get the member request
+    from sqlalchemy import select
+    from app.models.agency import AgencyMember
+
+    result = await db.execute(
+        select(AgencyMember).where(AgencyMember.id == member_id)
+    )
+    member = result.scalar_one_or_none()
+
+    if not member or member.agency_id != agency_id or member.status != "pending_request":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Join request not found",
+        )
+
+    success = await agency_service.reject_join_request(member_id)
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to reject join request",
+        )
+
+    return {"message": "Join request rejected"}
+
+
+# ============================================
+# Team Member Endpoints
+# ============================================
+
+@router.get("/team", response_model=List[AgencyMemberListResponse])
+async def list_team_members(
+    agency_id: UUID = Depends(get_user_agency_id),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> Any:
+    """
+    List all team members of the agency.
+    """
+    members = await agency_service.get_agency_members(agency_id, status="active")
+
+    return [
+        AgencyMemberListResponse(
+            id=member.id,
+            user_id=member.user_id,
+            role=member.role,
+            status=member.status,
+            user_email=member.user.email if member.user else "",
+            user_full_name=member.user.full_name if member.user else None,
+            joined_at=member.joined_at,
+        )
+        for member in members
+    ]
+
+
+@router.post("/team/invite", response_model=AgencyInvitationResponse, status_code=status.HTTP_201_CREATED)
+async def invite_team_member(
+    invite_data: AgencyInviteRequest,
+    admin_data: tuple = Depends(require_agency_admin),
+    agency_service: AgencyService = Depends(get_agency_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Invite a new team member to the agency.
+    Requires admin privileges.
+    Team members are agency users, not creators.
+    """
+    current_user, agency_id = admin_data
+
+    # Check if email already has a pending invitation
+    existing_invitations = await agency_service.get_agency_invitations(agency_id, status="pending")
+    for inv in existing_invitations:
+        if inv.email.lower() == invite_data.email.lower():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="An invitation has already been sent to this email",
+            )
+
+    # Check if user already exists
+    from app.services.user import UserService
+    user_service = UserService(db)
+    existing_user = await user_service.get_by_email(invite_data.email)
+
+    if existing_user:
+        # Check if already a member
+        is_member = await agency_service.is_user_agency_member(existing_user.id, agency_id)
+        if is_member:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="User is already a team member",
+            )
+
+    # Create invitation (for team members, we'll handle differently on accept)
+    invitation = await agency_service.create_invitation(
+        agency_id=agency_id,
+        email=invite_data.email,
+        invited_by=current_user.id,
+    )
+
+    # Store the role in invitation metadata or handle on accept
+    # For now, team invitations default to 'member' role
+
+    agency = await agency_service.get_by_id(agency_id)
+
+    # Send team invitation email
+    try:
+        send_creator_invitation_email.delay(
+            email=invite_data.email,
+            agency_name=agency.name,
+            invitation_token=invitation.token,
+            inviter_name=current_user.full_name,
+            is_team_invite=True,
+        )
+    except Exception as e:
+        logger.error(f"Failed to queue team invitation email: {e}")
+
+    return AgencyInvitationResponse(
+        id=invitation.id,
+        agency_id=invitation.agency_id,
+        email=invitation.email,
+        status=invitation.status,
+        invited_by=invitation.invited_by,
+        expires_at=invitation.expires_at,
+        accepted_at=invitation.accepted_at,
+        created_at=invitation.created_at,
+        agency_name=agency.name,
+        agency_logo_url=agency.logo_url,
+    )
+
+
+@router.patch("/team/{member_id}/role", response_model=AgencyMemberListResponse)
+async def update_team_member_role(
+    member_id: UUID,
+    role_update: AgencyMemberRoleUpdate,
+    admin_data: tuple = Depends(require_agency_admin),
+    agency_service: AgencyService = Depends(get_agency_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Update a team member's role.
+    Requires admin privileges. Cannot change owner role.
+    """
+    current_user, agency_id = admin_data
+
+    # Get the member
+    from sqlalchemy import select
+    from app.models.agency import AgencyMember
+
+    result = await db.execute(
+        select(AgencyMember).where(AgencyMember.id == member_id)
+    )
+    member = result.scalar_one_or_none()
+
+    if not member or member.agency_id != agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Team member not found",
+        )
+
+    # Can't change owner's role
+    if member.role == "owner":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot change owner's role",
+        )
+
+    # Can't change own role (unless owner)
+    membership = await agency_service.get_user_agency_membership(current_user.id)
+    if member.user_id == current_user.id and membership.role != "owner":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot change your own role",
+        )
+
+    updated_member = await agency_service.update_member_role(member_id, role_update.role)
+    if not updated_member:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update role",
+        )
+
+    # Refetch with user info
+    await db.refresh(updated_member)
+    user = await db.get(User, updated_member.user_id)
+
+    return AgencyMemberListResponse(
+        id=updated_member.id,
+        user_id=updated_member.user_id,
+        role=updated_member.role,
+        status=updated_member.status,
+        user_email=user.email if user else "",
+        user_full_name=user.full_name if user else None,
+        joined_at=updated_member.joined_at,
+    )
+
+
+@router.delete("/team/{member_id}")
+async def remove_team_member(
+    member_id: UUID,
+    admin_data: tuple = Depends(require_agency_admin),
+    agency_service: AgencyService = Depends(get_agency_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Remove a team member from the agency.
+    Requires admin privileges. Cannot remove owner.
+    """
+    current_user, agency_id = admin_data
+
+    # Get the member
+    from sqlalchemy import select
+    from app.models.agency import AgencyMember
+
+    result = await db.execute(
+        select(AgencyMember).where(AgencyMember.id == member_id)
+    )
+    member = result.scalar_one_or_none()
+
+    if not member or member.agency_id != agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Team member not found",
+        )
+
+    # Can't remove owner
+    if member.role == "owner":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot remove agency owner",
+        )
+
+    # Can't remove yourself
+    if member.user_id == current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot remove yourself. Use leave agency instead.",
+        )
+
+    success = await agency_service.remove_member(member_id)
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to remove team member",
+        )
+
+    return {"message": "Team member removed"}
+
+
+# ============================================
+# Agency Stats Endpoints
+# ============================================
+
+@router.get("/stats")
+async def get_agency_stats(
+    agency_id: UUID = Depends(get_user_agency_id),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> Any:
+    """
+    Get agency statistics for dashboard.
+    """
+    # Get creator count
+    creator_count = await agency_service.get_agency_creator_count(agency_id)
+
+    # Get pending invitations
+    pending_invitations = await agency_service.get_agency_invitations(agency_id, status="pending")
+
+    # Get pending join requests
+    join_requests = await agency_service.get_pending_join_requests(agency_id)
+
+    # Get team member count
+    team_members = await agency_service.get_agency_members(agency_id, status="active")
+
+    # TODO: Calculate total reach from creator analytics
+    total_reach = 0
+
+    # TODO: Get active opportunities count
+    active_opportunities = 0
+
+    return {
+        "creator_count": creator_count,
+        "team_member_count": len(team_members),
+        "pending_invitations": len(pending_invitations),
+        "pending_join_requests": len(join_requests),
+        "total_reach": total_reach,
+        "active_opportunities": active_opportunities,
+    }
+
+
+# ============================================
+# Public Agency Search (for Creators)
+# ============================================
+
+@router.get("/search", response_model=List[AgencyPublicResponse])
+async def search_agencies(
+    q: str = Query(..., min_length=1, max_length=100),
+    limit: int = Query(default=10, ge=1, le=50),
+    agency_service: AgencyService = Depends(get_agency_service),
+    current_user: User = Depends(get_current_user),
+) -> Any:
+    """
+    Search for agencies by name.
+    Used by creators to find agencies to join.
+    """
+    # Only creators should search for agencies
+    if current_user.account_type != "creator":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only creators can search for agencies",
+        )
+
+    agencies = await agency_service.search_agencies(q, limit)
+
+    return [
+        AgencyPublicResponse(
+            id=agency.id,
+            name=agency.name,
+            slug=agency.slug,
+            logo_url=agency.logo_url,
+            description=agency.description,
+            website=agency.website,
+        )
+        for agency in agencies
+    ]

--- a/backend/app/api/v1/endpoints/agency_auth.py
+++ b/backend/app/api/v1/endpoints/agency_auth.py
@@ -1,0 +1,147 @@
+"""
+Agency authentication endpoints.
+
+Handles agency signup and agency-specific auth operations.
+"""
+
+from datetime import timedelta
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.database import get_async_session
+from app.core.security import create_access_token, create_refresh_token
+from app.schemas.agency import AgencySignupRequest, AgencySignupResponse
+from app.schemas.user import UserCreate
+from app.services.agency_service import AgencyService
+from app.services.user import UserService
+from app.tasks.email import send_agency_signup_admin_notification
+
+router = APIRouter()
+
+
+@router.post("/signup", response_model=AgencySignupResponse, status_code=status.HTTP_201_CREATED)
+async def agency_signup(
+    *,
+    db: AsyncSession = Depends(get_async_session),
+    signup_data: AgencySignupRequest,
+) -> Any:
+    """
+    Create a new agency account.
+
+    This creates:
+    1. A new user account (agency owner)
+    2. A new agency
+    3. Links the user as agency owner
+
+    Agencies are auto-approved but an email notification is sent to admins.
+
+    Args:
+        db: Database session
+        signup_data: Agency signup data
+
+    Returns:
+        AgencySignupResponse: User ID, agency ID, and auth tokens
+
+    Raises:
+        HTTPException: If email already registered
+    """
+    user_service = UserService(db)
+    agency_service = AgencyService(db)
+
+    # Check if user exists
+    existing_user = await user_service.get_by_email(email=signup_data.email)
+    if existing_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email already registered",
+        )
+
+    # Create user account
+    user = await user_service.create(
+        user_create=UserCreate(
+            email=signup_data.email,
+            password=signup_data.password,
+            full_name=signup_data.full_name,
+        )
+    )
+
+    # Set user as agency type, auto-approved
+    user.account_type = "agency"
+    user.approval_status = "approved"  # Agencies are auto-approved
+    user.access_status = "full"  # Legacy field
+    user.user_kind = "content"  # Legacy field
+    user.has_account = True
+
+    await db.commit()
+    await db.refresh(user)
+
+    # Create the agency
+    agency = await agency_service.create_agency(
+        name=signup_data.agency_name,
+        owner_id=user.id,
+        website=signup_data.website,
+    )
+
+    # Create auth tokens
+    access_token = create_access_token(
+        subject=str(user.id),
+        expires_delta=timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES),
+    )
+    refresh_token = create_refresh_token(
+        subject=str(user.id),
+        expires_delta=timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS),
+    )
+
+    logger.info(f"Agency signup complete: {signup_data.agency_name} (user={user.email})")
+
+    # Send admin notification (async task)
+    try:
+        send_agency_signup_admin_notification.delay(
+            agency_name=signup_data.agency_name,
+            owner_email=user.email,
+            owner_name=signup_data.full_name,
+        )
+    except Exception as e:
+        # Don't fail signup if email notification fails
+        logger.error(f"Failed to queue agency signup notification: {e}")
+
+    return AgencySignupResponse(
+        user_id=user.id,
+        agency_id=agency.id,
+        agency_slug=agency.slug,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_type="bearer",
+    )
+
+
+@router.post("/complete-signup", response_model=AgencySignupResponse)
+async def complete_agency_signup(
+    *,
+    db: AsyncSession = Depends(get_async_session),
+    signup_data: AgencySignupRequest,
+) -> Any:
+    """
+    Complete agency signup for an existing user.
+
+    This is used when an existing user (e.g., creator) wants to
+    create an agency account.
+
+    NOTE: This endpoint is for future use. Currently, we require
+    a fresh signup for agencies.
+
+    Args:
+        db: Database session
+        signup_data: Agency signup data (only agency_name, website used)
+
+    Raises:
+        HTTPException: Not implemented yet
+    """
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="Converting existing accounts to agency accounts is not yet supported",
+    )

--- a/backend/app/api/v1/endpoints/agency_opportunities.py
+++ b/backend/app/api/v1/endpoints/agency_opportunities.py
@@ -1,0 +1,463 @@
+"""
+Agency opportunity management endpoints.
+
+Handles CRUD operations for sponsorship opportunities from the agency perspective.
+"""
+
+from datetime import datetime
+from typing import Any, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_async_session
+from app.core.security import get_current_user
+from app.models.user import User
+from app.schemas.agency_opportunity import (
+    AgencyOpportunityCreate,
+    AgencyOpportunityUpdate,
+    AgencyOpportunityResponse,
+    AgencyOpportunityListResponse,
+    OpportunityFilters,
+)
+from app.services.agency_service import AgencyService
+from app.services.agency_opportunity_service import AgencyOpportunityService
+from app.tasks.email import send_opportunity_notification
+
+router = APIRouter()
+
+
+# ============================================
+# Helper Functions
+# ============================================
+
+async def get_agency_service(db: AsyncSession = Depends(get_async_session)) -> AgencyService:
+    """Get agency service instance."""
+    return AgencyService(db)
+
+
+async def get_opportunity_service(db: AsyncSession = Depends(get_async_session)) -> AgencyOpportunityService:
+    """Get opportunity service instance."""
+    return AgencyOpportunityService(db)
+
+
+async def require_agency_user(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    """Require that the current user is an agency user."""
+    if current_user.account_type != "agency":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Agency account required",
+        )
+    return current_user
+
+
+async def get_user_agency_id(
+    current_user: User = Depends(require_agency_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> UUID:
+    """Get the agency ID for the current agency user."""
+    membership = await agency_service.get_user_agency_membership(current_user.id)
+    if not membership:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No agency found for user",
+        )
+    return membership.agency_id
+
+
+async def require_agency_admin(
+    current_user: User = Depends(require_agency_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> tuple[User, UUID]:
+    """Require that the current user is an agency admin (owner or admin role)."""
+    membership = await agency_service.get_user_agency_membership(current_user.id)
+    if not membership:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No agency found for user",
+        )
+
+    if membership.role not in ["owner", "admin"]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required",
+        )
+
+    return current_user, membership.agency_id
+
+
+# ============================================
+# Opportunity CRUD Endpoints
+# ============================================
+
+@router.post("/", response_model=AgencyOpportunityResponse, status_code=status.HTTP_201_CREATED)
+async def create_opportunity(
+    opportunity_data: AgencyOpportunityCreate,
+    send_immediately: bool = Query(default=False),
+    current_user: User = Depends(require_agency_user),
+    agency_id: UUID = Depends(get_user_agency_id),
+    agency_service: AgencyService = Depends(get_agency_service),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Create a new sponsorship opportunity.
+
+    By default creates as draft. Set send_immediately=true to send right away.
+    """
+    # Verify creator belongs to this agency
+    creator = await db.get(User, opportunity_data.creator_id)
+    if not creator:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Creator not found",
+        )
+
+    if creator.agency_id != agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Creator is not part of your agency",
+        )
+
+    # Create opportunity
+    opportunity = await opportunity_service.create_opportunity(
+        agency_id=agency_id,
+        creator_id=opportunity_data.creator_id,
+        created_by=current_user.id,
+        title=opportunity_data.title,
+        brand_name=opportunity_data.brand_name,
+        description=opportunity_data.description,
+        requirements=opportunity_data.requirements.model_dump() if opportunity_data.requirements else {},
+        compensation=opportunity_data.compensation.model_dump() if opportunity_data.compensation else {},
+        brand_logo_url=opportunity_data.brand_logo_url,
+        deadline=opportunity_data.deadline,
+        content_deadline=opportunity_data.content_deadline,
+        send_immediately=send_immediately,
+    )
+
+    # Send notification if sent immediately
+    if send_immediately:
+        try:
+            agency = await agency_service.get_by_id(agency_id)
+            send_opportunity_notification.delay(
+                creator_email=creator.email,
+                creator_name=creator.full_name or "Creator",
+                agency_name=agency.name,
+                opportunity_title=opportunity.title,
+                brand_name=opportunity.brand_name,
+            )
+        except Exception as e:
+            logger.error(f"Failed to send opportunity notification: {e}")
+
+    return AgencyOpportunityResponse(
+        id=opportunity.id,
+        agency_id=opportunity.agency_id,
+        creator_id=opportunity.creator_id,
+        created_by=opportunity.created_by,
+        title=opportunity.title,
+        brand_name=opportunity.brand_name,
+        brand_logo_url=opportunity.brand_logo_url,
+        description=opportunity.description,
+        requirements=opportunity.requirements,
+        compensation=opportunity.compensation,
+        deadline=opportunity.deadline,
+        content_deadline=opportunity.content_deadline,
+        status=opportunity.status,
+        sent_at=opportunity.sent_at,
+        viewed_at=opportunity.viewed_at,
+        creator_response_at=opportunity.creator_response_at,
+        creator_notes=opportunity.creator_notes,
+        project_id=opportunity.project_id,
+        created_at=opportunity.created_at,
+        updated_at=opportunity.updated_at,
+        creator_email=creator.email,
+        creator_full_name=creator.full_name,
+    )
+
+
+@router.get("/", response_model=List[AgencyOpportunityListResponse])
+async def list_opportunities(
+    opportunity_status: Optional[str] = Query(None, alias="status"),
+    creator_id: Optional[UUID] = None,
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    agency_id: UUID = Depends(get_user_agency_id),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+) -> Any:
+    """
+    List all opportunities for the agency.
+    """
+    opportunities = await opportunity_service.get_by_agency(
+        agency_id=agency_id,
+        status=opportunity_status,
+        creator_id=creator_id,
+        limit=limit,
+        offset=offset,
+    )
+
+    return [
+        AgencyOpportunityListResponse(
+            id=opp.id,
+            creator_id=opp.creator_id,
+            title=opp.title,
+            brand_name=opp.brand_name,
+            status=opp.status,
+            deadline=opp.deadline,
+            sent_at=opp.sent_at,
+            creator_full_name=opp.creator.full_name if opp.creator else None,
+            created_at=opp.created_at,
+        )
+        for opp in opportunities
+    ]
+
+
+@router.get("/stats")
+async def get_opportunity_stats(
+    agency_id: UUID = Depends(get_user_agency_id),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+) -> Any:
+    """
+    Get opportunity statistics for the agency.
+    """
+    stats = await opportunity_service.get_agency_stats(agency_id)
+    return stats
+
+
+@router.get("/{opportunity_id}", response_model=AgencyOpportunityResponse)
+async def get_opportunity(
+    opportunity_id: UUID,
+    agency_id: UUID = Depends(get_user_agency_id),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+) -> Any:
+    """
+    Get a specific opportunity by ID.
+    """
+    opportunity = await opportunity_service.get_by_id(opportunity_id)
+    if not opportunity or opportunity.agency_id != agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Opportunity not found",
+        )
+
+    return AgencyOpportunityResponse(
+        id=opportunity.id,
+        agency_id=opportunity.agency_id,
+        creator_id=opportunity.creator_id,
+        created_by=opportunity.created_by,
+        title=opportunity.title,
+        brand_name=opportunity.brand_name,
+        brand_logo_url=opportunity.brand_logo_url,
+        description=opportunity.description,
+        requirements=opportunity.requirements,
+        compensation=opportunity.compensation,
+        deadline=opportunity.deadline,
+        content_deadline=opportunity.content_deadline,
+        status=opportunity.status,
+        sent_at=opportunity.sent_at,
+        viewed_at=opportunity.viewed_at,
+        creator_response_at=opportunity.creator_response_at,
+        creator_notes=opportunity.creator_notes,
+        project_id=opportunity.project_id,
+        created_at=opportunity.created_at,
+        updated_at=opportunity.updated_at,
+        creator_email=opportunity.creator.email if opportunity.creator else None,
+        creator_full_name=opportunity.creator.full_name if opportunity.creator else None,
+    )
+
+
+@router.patch("/{opportunity_id}", response_model=AgencyOpportunityResponse)
+async def update_opportunity(
+    opportunity_id: UUID,
+    updates: AgencyOpportunityUpdate,
+    agency_id: UUID = Depends(get_user_agency_id),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+) -> Any:
+    """
+    Update an opportunity (only drafts can be fully edited).
+    """
+    opportunity = await opportunity_service.get_by_id(opportunity_id)
+    if not opportunity or opportunity.agency_id != agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Opportunity not found",
+        )
+
+    if opportunity.status != "draft":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only draft opportunities can be edited",
+        )
+
+    update_data = updates.model_dump(exclude_unset=True)
+    if "requirements" in update_data and update_data["requirements"]:
+        update_data["requirements"] = update_data["requirements"].model_dump() if hasattr(update_data["requirements"], "model_dump") else update_data["requirements"]
+    if "compensation" in update_data and update_data["compensation"]:
+        update_data["compensation"] = update_data["compensation"].model_dump() if hasattr(update_data["compensation"], "model_dump") else update_data["compensation"]
+
+    updated = await opportunity_service.update_opportunity(opportunity_id, **update_data)
+
+    return AgencyOpportunityResponse(
+        id=updated.id,
+        agency_id=updated.agency_id,
+        creator_id=updated.creator_id,
+        created_by=updated.created_by,
+        title=updated.title,
+        brand_name=updated.brand_name,
+        brand_logo_url=updated.brand_logo_url,
+        description=updated.description,
+        requirements=updated.requirements,
+        compensation=updated.compensation,
+        deadline=updated.deadline,
+        content_deadline=updated.content_deadline,
+        status=updated.status,
+        sent_at=updated.sent_at,
+        viewed_at=updated.viewed_at,
+        creator_response_at=updated.creator_response_at,
+        creator_notes=updated.creator_notes,
+        project_id=updated.project_id,
+        created_at=updated.created_at,
+        updated_at=updated.updated_at,
+        creator_email=updated.creator.email if updated.creator else None,
+        creator_full_name=updated.creator.full_name if updated.creator else None,
+    )
+
+
+@router.delete("/{opportunity_id}")
+async def delete_opportunity(
+    opportunity_id: UUID,
+    agency_id: UUID = Depends(get_user_agency_id),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+) -> Any:
+    """
+    Delete a draft opportunity.
+    """
+    opportunity = await opportunity_service.get_by_id(opportunity_id)
+    if not opportunity or opportunity.agency_id != agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Opportunity not found",
+        )
+
+    success = await opportunity_service.delete_opportunity(opportunity_id)
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only draft opportunities can be deleted",
+        )
+
+    return {"message": "Opportunity deleted"}
+
+
+# ============================================
+# Opportunity Actions
+# ============================================
+
+@router.post("/{opportunity_id}/send")
+async def send_opportunity(
+    opportunity_id: UUID,
+    agency_id: UUID = Depends(get_user_agency_id),
+    agency_service: AgencyService = Depends(get_agency_service),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Send a draft opportunity to the creator.
+    """
+    opportunity = await opportunity_service.get_by_id(opportunity_id)
+    if not opportunity or opportunity.agency_id != agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Opportunity not found",
+        )
+
+    if opportunity.status != "draft":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only draft opportunities can be sent",
+        )
+
+    sent = await opportunity_service.send_opportunity(opportunity_id)
+    if not sent:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to send opportunity",
+        )
+
+    # Send notification to creator
+    try:
+        creator = await db.get(User, opportunity.creator_id)
+        agency = await agency_service.get_by_id(agency_id)
+        if creator and agency:
+            send_opportunity_notification.delay(
+                creator_email=creator.email,
+                creator_name=creator.full_name or "Creator",
+                agency_name=agency.name,
+                opportunity_title=opportunity.title,
+                brand_name=opportunity.brand_name,
+            )
+    except Exception as e:
+        logger.error(f"Failed to send opportunity notification: {e}")
+
+    return {"message": "Opportunity sent to creator"}
+
+
+@router.post("/{opportunity_id}/cancel")
+async def cancel_opportunity(
+    opportunity_id: UUID,
+    agency_id: UUID = Depends(get_user_agency_id),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+) -> Any:
+    """
+    Cancel an opportunity.
+    """
+    opportunity = await opportunity_service.get_by_id(opportunity_id)
+    if not opportunity or opportunity.agency_id != agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Opportunity not found",
+        )
+
+    cancelled = await opportunity_service.cancel_opportunity(opportunity_id)
+    if not cancelled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot cancel this opportunity",
+        )
+
+    return {"message": "Opportunity cancelled"}
+
+
+@router.post("/{opportunity_id}/complete")
+async def complete_opportunity(
+    opportunity_id: UUID,
+    agency_id: UUID = Depends(get_user_agency_id),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+) -> Any:
+    """
+    Mark an accepted opportunity as completed.
+    """
+    opportunity = await opportunity_service.get_by_id(opportunity_id)
+    if not opportunity or opportunity.agency_id != agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Opportunity not found",
+        )
+
+    if opportunity.status != "accepted":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only accepted opportunities can be marked as completed",
+        )
+
+    completed = await opportunity_service.complete_opportunity(opportunity_id)
+    if not completed:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to complete opportunity",
+        )
+
+    return {"message": "Opportunity marked as completed"}

--- a/backend/app/api/v1/endpoints/creator_agency.py
+++ b/backend/app/api/v1/endpoints/creator_agency.py
@@ -1,0 +1,530 @@
+"""
+Creator-side agency endpoints.
+
+Handles creator operations related to agencies: viewing agency info,
+accepting invitations, requesting to join, and leaving agencies.
+"""
+
+from datetime import datetime
+from typing import Any, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_async_session
+from app.core.security import get_current_user
+from app.models.user import User
+from app.models.agency import Agency, AgencyMember, AgencyInvitation
+from app.schemas.agency import (
+    AgencyPublicResponse,
+    CreatorAgencyResponse,
+    PendingInvitationResponse,
+    AgencyJoinRequest,
+)
+from app.services.agency_service import AgencyService
+from app.tasks.email import send_join_request_notification, send_join_request_accepted_email
+
+router = APIRouter()
+
+
+# ============================================
+# Helper Functions
+# ============================================
+
+async def get_agency_service(db: AsyncSession = Depends(get_async_session)) -> AgencyService:
+    """Get agency service instance."""
+    return AgencyService(db)
+
+
+async def require_creator_user(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    """Require that the current user is a creator."""
+    if current_user.account_type != "creator":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Creator account required",
+        )
+    return current_user
+
+
+# ============================================
+# Creator Agency Status Endpoints
+# ============================================
+
+@router.get("/current", response_model=Optional[CreatorAgencyResponse])
+async def get_current_agency(
+    current_user: User = Depends(require_creator_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Get the creator's current agency (if any).
+    Returns null if creator is not part of any agency.
+    """
+    if not current_user.agency_id:
+        return None
+
+    agency = await agency_service.get_by_id(current_user.agency_id)
+    if not agency:
+        return None
+
+    # Get membership details if exists
+    membership = await agency_service.get_user_agency_membership(current_user.id)
+
+    return CreatorAgencyResponse(
+        agency_id=agency.id,
+        agency_name=agency.name,
+        agency_slug=agency.slug,
+        agency_logo_url=agency.logo_url,
+        role=membership.role if membership else "member",
+        joined_at=membership.joined_at if membership else None,
+    )
+
+
+@router.delete("/leave")
+async def leave_agency(
+    current_user: User = Depends(require_creator_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Leave the current agency.
+    Creator will be unlinked from the agency.
+    """
+    if not current_user.agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You are not part of any agency",
+        )
+
+    agency = await agency_service.get_by_id(current_user.agency_id)
+    agency_name = agency.name if agency else "Unknown"
+
+    success = await agency_service.unlink_creator_from_agency(current_user.id)
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to leave agency",
+        )
+
+    logger.info(f"Creator {current_user.email} left agency {agency_name}")
+    return {"message": f"You have left {agency_name}"}
+
+
+# ============================================
+# Invitation Endpoints (Creator Side)
+# ============================================
+
+@router.get("/invitations", response_model=List[PendingInvitationResponse])
+async def get_pending_invitations(
+    current_user: User = Depends(require_creator_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> Any:
+    """
+    Get all pending agency invitations for the current creator.
+    """
+    invitations = await agency_service.get_pending_invitations_for_email(current_user.email)
+
+    return [
+        PendingInvitationResponse(
+            id=inv.id,
+            agency_id=inv.agency_id,
+            agency_name=inv.agency.name if inv.agency else "Unknown",
+            agency_logo_url=inv.agency.logo_url if inv.agency else None,
+            invited_at=inv.created_at,
+            expires_at=inv.expires_at,
+        )
+        for inv in invitations
+    ]
+
+
+@router.post("/invitations/{invitation_id}/accept")
+async def accept_invitation(
+    invitation_id: UUID,
+    current_user: User = Depends(require_creator_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Accept an agency invitation.
+    Creator will be linked to the agency.
+    """
+    # Check if creator is already in an agency
+    if current_user.agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You are already part of an agency. Leave your current agency first.",
+        )
+
+    # Get and validate invitation
+    invitation = await agency_service.get_invitation_by_id(invitation_id)
+    if not invitation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Invitation not found",
+        )
+
+    # Verify invitation is for this user
+    if invitation.email.lower() != current_user.email.lower():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This invitation is not for you",
+        )
+
+    # Check if invitation is still valid
+    if invitation.status != "pending":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invitation is {invitation.status}",
+        )
+
+    if invitation.expires_at < datetime.utcnow():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invitation has expired",
+        )
+
+    # Accept the invitation
+    await agency_service.accept_invitation(invitation_id)
+
+    # Link creator to agency
+    await agency_service.link_creator_to_agency(current_user.id, invitation.agency_id)
+
+    agency = await agency_service.get_by_id(invitation.agency_id)
+    agency_name = agency.name if agency else "Unknown"
+
+    logger.info(f"Creator {current_user.email} accepted invitation to join {agency_name}")
+    return {"message": f"You have joined {agency_name}"}
+
+
+@router.post("/invitations/{invitation_id}/decline")
+async def decline_invitation(
+    invitation_id: UUID,
+    current_user: User = Depends(require_creator_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> Any:
+    """
+    Decline an agency invitation.
+    """
+    invitation = await agency_service.get_invitation_by_id(invitation_id)
+    if not invitation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Invitation not found",
+        )
+
+    # Verify invitation is for this user
+    if invitation.email.lower() != current_user.email.lower():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This invitation is not for you",
+        )
+
+    if invitation.status != "pending":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invitation is already {invitation.status}",
+        )
+
+    # Cancel/decline the invitation
+    await agency_service.cancel_invitation(invitation_id)
+
+    return {"message": "Invitation declined"}
+
+
+@router.get("/invitations/by-token")
+async def get_invitation_by_token(
+    token: str = Query(..., min_length=1),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> Any:
+    """
+    Get invitation details by token.
+    Used for the invitation acceptance page.
+    This endpoint does not require authentication.
+    """
+    invitation = await agency_service.get_invitation_by_token(token)
+    if not invitation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Invitation not found or expired",
+        )
+
+    if invitation.status != "pending":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invitation is {invitation.status}",
+        )
+
+    if invitation.expires_at < datetime.utcnow():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invitation has expired",
+        )
+
+    return {
+        "id": invitation.id,
+        "email": invitation.email,
+        "agency_id": invitation.agency_id,
+        "agency_name": invitation.agency.name if invitation.agency else "Unknown",
+        "agency_logo_url": invitation.agency.logo_url if invitation.agency else None,
+        "expires_at": invitation.expires_at,
+    }
+
+
+@router.post("/invitations/accept-by-token")
+async def accept_invitation_by_token(
+    token: str = Query(..., min_length=1),
+    current_user: User = Depends(require_creator_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Accept an invitation using the token.
+    Used when user clicks link in email and is already logged in.
+    """
+    # Check if creator is already in an agency
+    if current_user.agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You are already part of an agency. Leave your current agency first.",
+        )
+
+    invitation = await agency_service.get_invitation_by_token(token)
+    if not invitation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Invitation not found",
+        )
+
+    # Verify invitation is for this user
+    if invitation.email.lower() != current_user.email.lower():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This invitation is not for your email address",
+        )
+
+    if invitation.status != "pending":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invitation is {invitation.status}",
+        )
+
+    if invitation.expires_at < datetime.utcnow():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invitation has expired",
+        )
+
+    # Accept the invitation
+    await agency_service.accept_invitation(invitation.id)
+
+    # Link creator to agency
+    await agency_service.link_creator_to_agency(current_user.id, invitation.agency_id)
+
+    agency = await agency_service.get_by_id(invitation.agency_id)
+    agency_name = agency.name if agency else "Unknown"
+
+    logger.info(f"Creator {current_user.email} accepted invitation (by token) to join {agency_name}")
+    return {
+        "message": f"You have joined {agency_name}",
+        "agency_id": invitation.agency_id,
+        "agency_name": agency_name,
+    }
+
+
+# ============================================
+# Join Request Endpoints (Creator Side)
+# ============================================
+
+@router.post("/join/{agency_id}")
+async def request_to_join_agency(
+    agency_id: UUID,
+    join_request: AgencyJoinRequest = None,
+    current_user: User = Depends(require_creator_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Request to join an agency.
+    Agency admins will be notified and can accept or reject.
+    """
+    # Check if creator is already in an agency
+    if current_user.agency_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You are already part of an agency. Leave your current agency first.",
+        )
+
+    # Check if agency exists
+    agency = await agency_service.get_by_id(agency_id)
+    if not agency or not agency.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Agency not found",
+        )
+
+    # Check if user can join an agency
+    can_join = await agency_service.check_user_can_join_agency(current_user.id)
+    if not can_join:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You already have a pending request or membership",
+        )
+
+    # Check for existing pending request
+    existing_members = await agency_service.get_agency_members(agency_id, status="pending_request")
+    for member in existing_members:
+        if member.user_id == current_user.id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="You already have a pending request to join this agency",
+            )
+
+    # Create join request
+    await agency_service.create_join_request(agency_id, current_user.id)
+
+    # Notify agency admins
+    try:
+        # Get agency owner
+        owner = await db.get(User, agency.owner_id)
+        if owner:
+            send_join_request_notification.delay(
+                agency_admin_email=owner.email,
+                agency_admin_name=owner.full_name or "Admin",
+                agency_name=agency.name,
+                creator_name=current_user.full_name or current_user.email,
+                creator_email=current_user.email,
+            )
+    except Exception as e:
+        logger.error(f"Failed to send join request notification: {e}")
+
+    logger.info(f"Creator {current_user.email} requested to join agency {agency.name}")
+    return {"message": f"Your request to join {agency.name} has been submitted"}
+
+
+@router.get("/join-requests", response_model=List[dict])
+async def get_my_join_requests(
+    current_user: User = Depends(require_creator_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Get all pending join requests submitted by the creator.
+    """
+    result = await db.execute(
+        select(AgencyMember)
+        .where(
+            AgencyMember.user_id == current_user.id,
+            AgencyMember.status == "pending_request",
+        )
+    )
+    requests = result.scalars().all()
+
+    response = []
+    for req in requests:
+        agency = await agency_service.get_by_id(req.agency_id)
+        response.append({
+            "id": req.id,
+            "agency_id": req.agency_id,
+            "agency_name": agency.name if agency else "Unknown",
+            "agency_logo_url": agency.logo_url if agency else None,
+            "requested_at": req.created_at,
+            "status": req.status,
+        })
+
+    return response
+
+
+@router.delete("/join-requests/{request_id}")
+async def cancel_join_request(
+    request_id: UUID,
+    current_user: User = Depends(require_creator_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Cancel a pending join request.
+    """
+    result = await db.execute(
+        select(AgencyMember).where(AgencyMember.id == request_id)
+    )
+    member = result.scalar_one_or_none()
+
+    if not member or member.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Join request not found",
+        )
+
+    if member.status != "pending_request":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This request is no longer pending",
+        )
+
+    # Delete the request
+    await db.delete(member)
+    await db.commit()
+
+    return {"message": "Join request cancelled"}
+
+
+# ============================================
+# Agency Search (for Creators)
+# ============================================
+
+@router.get("/search", response_model=List[AgencyPublicResponse])
+async def search_agencies(
+    q: str = Query(..., min_length=1, max_length=100),
+    limit: int = Query(default=10, ge=1, le=50),
+    current_user: User = Depends(require_creator_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> Any:
+    """
+    Search for agencies by name.
+    Used by creators to find agencies to join.
+    """
+    agencies = await agency_service.search_agencies(q, limit)
+
+    return [
+        AgencyPublicResponse(
+            id=agency.id,
+            name=agency.name,
+            slug=agency.slug,
+            logo_url=agency.logo_url,
+            description=agency.description,
+            website=agency.website,
+        )
+        for agency in agencies
+    ]
+
+
+@router.get("/{agency_id}", response_model=AgencyPublicResponse)
+async def get_agency_details(
+    agency_id: UUID,
+    current_user: User = Depends(require_creator_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+) -> Any:
+    """
+    Get public details of an agency.
+    Used by creators when viewing agency before requesting to join.
+    """
+    agency = await agency_service.get_by_id(agency_id)
+    if not agency or not agency.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Agency not found",
+        )
+
+    return AgencyPublicResponse(
+        id=agency.id,
+        name=agency.name,
+        slug=agency.slug,
+        logo_url=agency.logo_url,
+        description=agency.description,
+        website=agency.website,
+    )

--- a/backend/app/api/v1/endpoints/creator_opportunities.py
+++ b/backend/app/api/v1/endpoints/creator_opportunities.py
@@ -1,0 +1,342 @@
+"""
+Creator-side opportunity endpoints.
+
+Handles viewing and responding to sponsorship opportunities from the creator perspective.
+"""
+
+from datetime import datetime
+from typing import Any, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_async_session
+from app.core.security import get_current_user
+from app.models.user import User
+from app.schemas.agency_opportunity import (
+    CreatorOpportunityResponse,
+    CreatorOpportunityListResponse,
+    OpportunityAcceptRequest,
+    OpportunityDeclineRequest,
+)
+from app.services.agency_service import AgencyService
+from app.services.agency_opportunity_service import AgencyOpportunityService
+from app.tasks.email import send_opportunity_response_notification
+
+router = APIRouter()
+
+
+# ============================================
+# Helper Functions
+# ============================================
+
+async def get_agency_service(db: AsyncSession = Depends(get_async_session)) -> AgencyService:
+    """Get agency service instance."""
+    return AgencyService(db)
+
+
+async def get_opportunity_service(db: AsyncSession = Depends(get_async_session)) -> AgencyOpportunityService:
+    """Get opportunity service instance."""
+    return AgencyOpportunityService(db)
+
+
+async def require_creator_user(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    """Require that the current user is a creator."""
+    if current_user.account_type != "creator":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Creator account required",
+        )
+    return current_user
+
+
+# ============================================
+# Opportunity List Endpoints
+# ============================================
+
+@router.get("/", response_model=List[CreatorOpportunityListResponse])
+async def list_my_opportunities(
+    opportunity_status: Optional[str] = Query(None, alias="status"),
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    current_user: User = Depends(require_creator_user),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+) -> Any:
+    """
+    List all opportunities sent to the current creator.
+    """
+    opportunities = await opportunity_service.get_by_creator(
+        creator_id=current_user.id,
+        status=opportunity_status,
+        limit=limit,
+        offset=offset,
+    )
+
+    return [
+        CreatorOpportunityListResponse(
+            id=opp.id,
+            agency_name=opp.agency.name if opp.agency else "Unknown",
+            title=opp.title,
+            brand_name=opp.brand_name,
+            status=opp.status,
+            deadline=opp.deadline,
+            sent_at=opp.sent_at,
+        )
+        for opp in opportunities
+    ]
+
+
+@router.get("/pending", response_model=List[CreatorOpportunityListResponse])
+async def list_pending_opportunities(
+    current_user: User = Depends(require_creator_user),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+) -> Any:
+    """
+    List pending opportunities (sent or viewed, not yet responded).
+    """
+    opportunities = await opportunity_service.get_pending_for_creator(current_user.id)
+
+    return [
+        CreatorOpportunityListResponse(
+            id=opp.id,
+            agency_name=opp.agency.name if opp.agency else "Unknown",
+            title=opp.title,
+            brand_name=opp.brand_name,
+            status=opp.status,
+            deadline=opp.deadline,
+            sent_at=opp.sent_at,
+        )
+        for opp in opportunities
+    ]
+
+
+@router.get("/count")
+async def count_opportunities(
+    current_user: User = Depends(require_creator_user),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+) -> Any:
+    """
+    Get counts of opportunities by status.
+    """
+    pending_sent = await opportunity_service.count_by_creator(current_user.id, status="sent")
+    pending_viewed = await opportunity_service.count_by_creator(current_user.id, status="viewed")
+    accepted = await opportunity_service.count_by_creator(current_user.id, status="accepted")
+    declined = await opportunity_service.count_by_creator(current_user.id, status="declined")
+    completed = await opportunity_service.count_by_creator(current_user.id, status="completed")
+
+    return {
+        "pending": pending_sent + pending_viewed,
+        "accepted": accepted,
+        "declined": declined,
+        "completed": completed,
+        "total": pending_sent + pending_viewed + accepted + declined + completed,
+    }
+
+
+# ============================================
+# Opportunity Detail Endpoints
+# ============================================
+
+@router.get("/{opportunity_id}", response_model=CreatorOpportunityResponse)
+async def get_opportunity(
+    opportunity_id: UUID,
+    current_user: User = Depends(require_creator_user),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+) -> Any:
+    """
+    Get a specific opportunity by ID.
+    Automatically marks as viewed when accessed.
+    """
+    opportunity = await opportunity_service.get_by_id(opportunity_id)
+    if not opportunity or opportunity.creator_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Opportunity not found",
+        )
+
+    # Don't show drafts to creators
+    if opportunity.status == "draft":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Opportunity not found",
+        )
+
+    # Mark as viewed if sent
+    if opportunity.status == "sent":
+        await opportunity_service.mark_as_viewed(opportunity_id)
+        opportunity.status = "viewed"
+        opportunity.viewed_at = datetime.utcnow()
+
+    return CreatorOpportunityResponse(
+        id=opportunity.id,
+        agency_id=opportunity.agency_id,
+        agency_name=opportunity.agency.name if opportunity.agency else "Unknown",
+        agency_logo_url=opportunity.agency.logo_url if opportunity.agency else None,
+        title=opportunity.title,
+        brand_name=opportunity.brand_name,
+        brand_logo_url=opportunity.brand_logo_url,
+        description=opportunity.description,
+        requirements=opportunity.requirements,
+        compensation=opportunity.compensation,
+        deadline=opportunity.deadline,
+        content_deadline=opportunity.content_deadline,
+        status=opportunity.status,
+        sent_at=opportunity.sent_at,
+        viewed_at=opportunity.viewed_at,
+        project_id=opportunity.project_id,
+        created_at=opportunity.created_at,
+    )
+
+
+# ============================================
+# Opportunity Response Endpoints
+# ============================================
+
+@router.post("/{opportunity_id}/accept")
+async def accept_opportunity(
+    opportunity_id: UUID,
+    accept_data: OpportunityAcceptRequest = None,
+    current_user: User = Depends(require_creator_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Accept a sponsorship opportunity.
+    This will create a monetization project for the opportunity.
+    """
+    opportunity = await opportunity_service.get_by_id(opportunity_id)
+    if not opportunity or opportunity.creator_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Opportunity not found",
+        )
+
+    if opportunity.status not in ["sent", "viewed"]:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot accept opportunity with status '{opportunity.status}'",
+        )
+
+    # Accept the opportunity
+    notes = accept_data.notes if accept_data else None
+    accepted = await opportunity_service.accept_opportunity(opportunity_id, notes)
+
+    if not accepted:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to accept opportunity",
+        )
+
+    # Create a monetization project
+    try:
+        from app.models.projects import ActiveProject
+
+        project = ActiveProject(
+            user_id=current_user.id,
+            title=f"[Sponsored] {opportunity.title}",
+            description=f"Sponsored content for {opportunity.brand_name}.\n\n{opportunity.description}",
+            status="pending",
+            project_type="sponsored_video",
+            ai_metadata={
+                "opportunity_id": str(opportunity_id),
+                "brand_name": opportunity.brand_name,
+                "requirements": opportunity.requirements,
+                "compensation": opportunity.compensation,
+                "content_deadline": opportunity.content_deadline.isoformat() if opportunity.content_deadline else None,
+            },
+        )
+        db.add(project)
+        await db.commit()
+        await db.refresh(project)
+
+        # Link project to opportunity
+        await opportunity_service.link_project(opportunity_id, project.id)
+
+        logger.info(f"Created project {project.id} for opportunity {opportunity_id}")
+    except Exception as e:
+        logger.error(f"Failed to create project for opportunity: {e}")
+        # Don't fail the accept - just log the error
+
+    # Notify agency
+    try:
+        agency = await agency_service.get_by_id(opportunity.agency_id)
+        if agency:
+            owner = await db.get(User, agency.owner_id)
+            if owner:
+                send_opportunity_response_notification.delay(
+                    agency_email=owner.email,
+                    agency_name=agency.name,
+                    creator_name=current_user.full_name or current_user.email,
+                    opportunity_title=opportunity.title,
+                    brand_name=opportunity.brand_name,
+                    response="accepted",
+                    notes=notes,
+                )
+    except Exception as e:
+        logger.error(f"Failed to send accept notification: {e}")
+
+    return {
+        "message": "Opportunity accepted",
+        "project_id": accepted.project_id,
+    }
+
+
+@router.post("/{opportunity_id}/decline")
+async def decline_opportunity(
+    opportunity_id: UUID,
+    decline_data: OpportunityDeclineRequest = None,
+    current_user: User = Depends(require_creator_user),
+    agency_service: AgencyService = Depends(get_agency_service),
+    opportunity_service: AgencyOpportunityService = Depends(get_opportunity_service),
+    db: AsyncSession = Depends(get_async_session),
+) -> Any:
+    """
+    Decline a sponsorship opportunity.
+    """
+    opportunity = await opportunity_service.get_by_id(opportunity_id)
+    if not opportunity or opportunity.creator_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Opportunity not found",
+        )
+
+    if opportunity.status not in ["sent", "viewed"]:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot decline opportunity with status '{opportunity.status}'",
+        )
+
+    # Decline the opportunity
+    reason = decline_data.reason if decline_data else None
+    declined = await opportunity_service.decline_opportunity(opportunity_id, reason)
+
+    if not declined:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to decline opportunity",
+        )
+
+    # Notify agency
+    try:
+        agency = await agency_service.get_by_id(opportunity.agency_id)
+        if agency:
+            owner = await db.get(User, agency.owner_id)
+            if owner:
+                send_opportunity_response_notification.delay(
+                    agency_email=owner.email,
+                    agency_name=agency.name,
+                    creator_name=current_user.full_name or current_user.email,
+                    opportunity_title=opportunity.title,
+                    brand_name=opportunity.brand_name,
+                    response="declined",
+                    notes=reason,
+                )
+    except Exception as e:
+        logger.error(f"Failed to send decline notification: {e}")
+
+    return {"message": "Opportunity declined"}

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -44,6 +44,8 @@ from app.models.content import (
 )
 from app.models.application import Application, AdminNotificationSettings
 from app.models.monetization import CreatorProfile
+from app.models.agency import Agency, AgencyMember, AgencyInvitation
+from app.models.agency_opportunity import AgencyOpportunity
 from app.models.credit_usage import (
     CreditUsageEvent,
     UserCreditBalance,
@@ -94,6 +96,10 @@ __all__ = [
     "Application",
     "AdminNotificationSettings",
     "CreatorProfile",
+    "Agency",
+    "AgencyMember",
+    "AgencyInvitation",
+    "AgencyOpportunity",
     "CreditUsageEvent",
     "UserCreditBalance",
     "CreditActionCost",

--- a/backend/app/models/agency.py
+++ b/backend/app/models/agency.py
@@ -1,0 +1,153 @@
+"""Agency models for talent management agencies."""
+
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy import (
+    Boolean, Column, DateTime, ForeignKey, String, Text,
+    UniqueConstraint, Index
+)
+from sqlalchemy.dialects.postgresql import ENUM as PG_ENUM, JSONB, UUID as PGUUID
+from sqlalchemy.orm import relationship
+
+from app.core.database import Base
+
+
+class Agency(Base):
+    """Agency model for talent management agencies."""
+
+    __tablename__ = "agencies"
+
+    name = Column(String(255), nullable=False, comment="Agency display name")
+    slug = Column(String(255), unique=True, nullable=False, index=True, comment="URL-friendly unique identifier")
+    owner_id = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False,
+        comment="User who created/owns the agency"
+    )
+
+    logo_url = Column(String(500), nullable=True, comment="URL to agency logo")
+    website = Column(String(500), nullable=True, comment="Agency website URL")
+    description = Column(Text, nullable=True, comment="Agency description")
+
+    settings = Column(JSONB, nullable=False, default=dict, comment="Agency settings and preferences")
+    is_active = Column(Boolean, default=True, nullable=False, comment="Whether agency is active")
+
+    # Relationships
+    owner = relationship("User", foreign_keys=[owner_id], backref="owned_agencies")
+    members = relationship("AgencyMember", back_populates="agency", cascade="all, delete-orphan")
+    invitations = relationship("AgencyInvitation", back_populates="agency", cascade="all, delete-orphan")
+    opportunities = relationship("AgencyOpportunity", back_populates="agency", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        Index("idx_agencies_owner_id", "owner_id"),
+        Index("idx_agencies_is_active", "is_active"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<Agency(id={self.id}, name='{self.name}', slug='{self.slug}')>"
+
+
+class AgencyMember(Base):
+    """Agency member model - links users to agencies with roles."""
+
+    __tablename__ = "agency_members"
+
+    agency_id = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("agencies.id", ondelete="CASCADE"),
+        nullable=False,
+        comment="The agency this membership belongs to"
+    )
+    user_id = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        comment="The user who is a member"
+    )
+
+    role = Column(
+        PG_ENUM('owner', 'admin', 'member', name='agency_member_role_enum', create_type=False),
+        nullable=False,
+        default='member',
+        comment="Member's role in the agency"
+    )
+    status = Column(
+        PG_ENUM('pending_invite', 'pending_request', 'active', 'removed', name='agency_member_status_enum', create_type=False),
+        nullable=False,
+        default='pending_invite',
+        comment="Membership status"
+    )
+
+    invited_by = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=True,
+        comment="User who sent the invitation"
+    )
+    invited_at = Column(DateTime(timezone=True), nullable=True, comment="When invitation was sent")
+    joined_at = Column(DateTime(timezone=True), nullable=True, comment="When user joined/accepted")
+
+    # Relationships
+    agency = relationship("Agency", back_populates="members")
+    user = relationship("User", foreign_keys=[user_id], backref="agency_memberships")
+    inviter = relationship("User", foreign_keys=[invited_by])
+
+    __table_args__ = (
+        UniqueConstraint("agency_id", "user_id", name="uq_agency_members_agency_user"),
+        Index("idx_agency_members_agency_id", "agency_id"),
+        Index("idx_agency_members_user_id", "user_id"),
+        Index("idx_agency_members_status", "status"),
+        Index("idx_agency_members_role", "role"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<AgencyMember(agency_id={self.agency_id}, user_id={self.user_id}, role='{self.role}', status='{self.status}')>"
+
+
+class AgencyInvitation(Base):
+    """Agency invitation model - for inviting non-users by email."""
+
+    __tablename__ = "agency_invitations"
+
+    agency_id = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("agencies.id", ondelete="CASCADE"),
+        nullable=False,
+        comment="The agency sending the invitation"
+    )
+    email = Column(String(255), nullable=False, comment="Email address of invitee")
+    token = Column(String(255), unique=True, nullable=False, comment="Unique invitation token")
+
+    invited_by = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False,
+        comment="User who sent the invitation"
+    )
+
+    expires_at = Column(DateTime(timezone=True), nullable=False, comment="When invitation expires")
+    accepted_at = Column(DateTime(timezone=True), nullable=True, comment="When invitation was accepted")
+
+    status = Column(
+        PG_ENUM('pending', 'accepted', 'expired', 'cancelled', name='agency_invitation_status_enum', create_type=False),
+        nullable=False,
+        default='pending',
+        comment="Invitation status"
+    )
+
+    # Relationships
+    agency = relationship("Agency", back_populates="invitations")
+    inviter = relationship("User", foreign_keys=[invited_by])
+
+    __table_args__ = (
+        Index("idx_agency_invitations_agency_id", "agency_id"),
+        Index("idx_agency_invitations_email", "email"),
+        Index("idx_agency_invitations_token", "token"),
+        Index("idx_agency_invitations_status", "status"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<AgencyInvitation(agency_id={self.agency_id}, email='{self.email}', status='{self.status}')>"

--- a/backend/app/models/agency_opportunity.py
+++ b/backend/app/models/agency_opportunity.py
@@ -1,0 +1,127 @@
+"""Agency opportunity model for sponsorship deals pushed to creators."""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    Column, DateTime, ForeignKey, String, Text, Index
+)
+from sqlalchemy.dialects.postgresql import ENUM as PG_ENUM, JSONB, UUID as PGUUID
+from sqlalchemy.orm import relationship
+
+from app.core.database import Base
+
+
+class AgencyOpportunity(Base):
+    """Agency opportunity model - sponsorship deals pushed from agencies to creators."""
+
+    __tablename__ = "agency_opportunities"
+
+    agency_id = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("agencies.id", ondelete="CASCADE"),
+        nullable=False,
+        comment="The agency creating/sending this opportunity"
+    )
+    creator_id = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False,
+        comment="The creator this opportunity is for"
+    )
+    created_by = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False,
+        comment="Agency user who created this opportunity"
+    )
+
+    # Opportunity Details
+    title = Column(String(255), nullable=False, comment="Opportunity title")
+    brand_name = Column(String(255), nullable=False, comment="Brand/sponsor name")
+    brand_logo_url = Column(String(500), nullable=True, comment="URL to brand logo")
+    description = Column(Text, nullable=False, comment="Detailed opportunity description")
+
+    # Structured Data
+    requirements = Column(
+        JSONB,
+        nullable=False,
+        default=dict,
+        comment="Deliverables and content requirements"
+    )
+    # Example requirements structure:
+    # {
+    #   "deliverables": ["1x YouTube video (10+ min)", "3x Instagram stories"],
+    #   "content_guidelines": "Family-friendly, mention product within first 2 minutes",
+    #   "talking_points": ["Feature A", "Feature B"],
+    #   "restrictions": ["No competitor mentions"]
+    # }
+
+    compensation = Column(
+        JSONB,
+        nullable=False,
+        default=dict,
+        comment="Payment terms and compensation details"
+    )
+    # Example compensation structure:
+    # {
+    #   "type": "flat_fee" | "cpm" | "hybrid" | "product_only",
+    #   "amount": 5000,
+    #   "currency": "USD",
+    #   "payment_terms": "50% upfront, 50% on delivery",
+    #   "product_value": 500,
+    #   "notes": "Bonus $500 if video exceeds 100k views"
+    # }
+
+    deadline = Column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Deadline to respond to the opportunity"
+    )
+    content_deadline = Column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Deadline to deliver the content"
+    )
+
+    # Status Tracking
+    status = Column(
+        PG_ENUM(
+            'draft', 'sent', 'viewed', 'accepted', 'declined', 'completed', 'cancelled',
+            name='agency_opportunity_status_enum',
+            create_type=False
+        ),
+        nullable=False,
+        default='draft',
+        comment="Current opportunity status"
+    )
+
+    sent_at = Column(DateTime(timezone=True), nullable=True, comment="When opportunity was sent to creator")
+    viewed_at = Column(DateTime(timezone=True), nullable=True, comment="When creator first viewed the opportunity")
+    creator_response_at = Column(DateTime(timezone=True), nullable=True, comment="When creator responded")
+    creator_notes = Column(Text, nullable=True, comment="Notes from creator (on accept/decline)")
+
+    # Link to monetization project (created on acceptance)
+    project_id = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("active_projects.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="Linked monetization project (created when accepted)"
+    )
+
+    # Relationships
+    agency = relationship("Agency", back_populates="opportunities")
+    creator = relationship("User", foreign_keys=[creator_id], backref="agency_opportunities_received")
+    created_by_user = relationship("User", foreign_keys=[created_by])
+    project = relationship("ActiveProject", backref="agency_opportunity")
+
+    __table_args__ = (
+        Index("idx_agency_opportunities_agency_id", "agency_id"),
+        Index("idx_agency_opportunities_creator_id", "creator_id"),
+        Index("idx_agency_opportunities_status", "status"),
+        Index("idx_agency_opportunities_created_by", "created_by"),
+        Index("idx_agency_opportunities_sent_at", "sent_at"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<AgencyOpportunity(id={self.id}, title='{self.title}', status='{self.status}')>"

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -136,9 +136,16 @@ class User(Base):
 
     # Foreign keys
     organization_id = Column(PGUUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True)
+    agency_id = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("agencies.id"),
+        nullable=True,
+        comment="Agency the creator belongs to (for creators only)"
+    )
 
     # Relationships
     organization = relationship("Organization", back_populates="users")
+    agency = relationship("Agency", foreign_keys=[agency_id], backref="creators")
     response_templates = relationship("ResponseTemplate", back_populates="created_by")
     automation_rules = relationship("AutomationRule", back_populates="created_by")
     audit_logs = relationship("AuditLog", back_populates="user", cascade="all, delete-orphan")

--- a/backend/app/schemas/agency.py
+++ b/backend/app/schemas/agency.py
@@ -1,0 +1,236 @@
+"""
+Agency schemas for request/response validation.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr, Field, field_validator
+
+
+# Type aliases
+AgencyMemberRole = Literal["owner", "admin", "member"]
+AgencyMemberStatus = Literal["pending_invite", "pending_request", "active", "removed"]
+AgencyInvitationStatus = Literal["pending", "accepted", "expired", "cancelled"]
+
+
+# ============================================
+# Agency Schemas
+# ============================================
+
+class AgencyCreate(BaseModel):
+    """Schema for creating an agency."""
+    name: str = Field(..., min_length=1, max_length=255)
+    website: Optional[str] = Field(None, max_length=500)
+    description: Optional[str] = None
+
+    @field_validator('website', mode='before')
+    @classmethod
+    def empty_str_to_none(cls, v):
+        if v == '' or v is None:
+            return None
+        return v
+
+
+class AgencyUpdate(BaseModel):
+    """Schema for updating an agency."""
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    logo_url: Optional[str] = Field(None, max_length=500)
+    website: Optional[str] = Field(None, max_length=500)
+    description: Optional[str] = None
+    settings: Optional[Dict[str, Any]] = None
+
+    @field_validator('website', 'logo_url', mode='before')
+    @classmethod
+    def empty_str_to_none(cls, v):
+        if v == '' or v is None:
+            return None
+        return v
+
+
+class AgencyResponse(BaseModel):
+    """Agency response schema."""
+    id: UUID
+    name: str
+    slug: str
+    owner_id: UUID
+    logo_url: Optional[str] = None
+    website: Optional[str] = None
+    description: Optional[str] = None
+    settings: Dict[str, Any] = {}
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class AgencyListResponse(BaseModel):
+    """Simplified agency list response."""
+    id: UUID
+    name: str
+    slug: str
+    logo_url: Optional[str] = None
+    creator_count: int = 0
+    is_active: bool
+
+
+class AgencyPublicResponse(BaseModel):
+    """Public agency info (for creator search)."""
+    id: UUID
+    name: str
+    slug: str
+    logo_url: Optional[str] = None
+    description: Optional[str] = None
+    website: Optional[str] = None
+
+
+# ============================================
+# Agency Signup Schemas
+# ============================================
+
+class AgencySignupRequest(BaseModel):
+    """Schema for agency signup."""
+    email: EmailStr
+    password: str = Field(..., min_length=8)
+    full_name: str = Field(..., min_length=1, max_length=255)
+    agency_name: str = Field(..., min_length=1, max_length=255)
+    website: Optional[str] = Field(None, max_length=500)
+
+    @field_validator('website', mode='before')
+    @classmethod
+    def empty_str_to_none(cls, v):
+        if v == '' or v is None:
+            return None
+        return v
+
+
+class AgencySignupResponse(BaseModel):
+    """Response after successful agency signup."""
+    user_id: UUID
+    agency_id: UUID
+    agency_slug: str
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+# ============================================
+# Agency Member Schemas
+# ============================================
+
+class AgencyMemberResponse(BaseModel):
+    """Agency member response schema."""
+    id: UUID
+    agency_id: UUID
+    user_id: UUID
+    role: AgencyMemberRole
+    status: AgencyMemberStatus
+    invited_by: Optional[UUID] = None
+    invited_at: Optional[datetime] = None
+    joined_at: Optional[datetime] = None
+    created_at: datetime
+    updated_at: datetime
+
+    # User info (populated via join)
+    user_email: Optional[str] = None
+    user_full_name: Optional[str] = None
+    user_avatar_url: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class AgencyMemberListResponse(BaseModel):
+    """Simplified member list response."""
+    id: UUID
+    user_id: UUID
+    role: AgencyMemberRole
+    status: AgencyMemberStatus
+    user_email: str
+    user_full_name: Optional[str] = None
+    joined_at: Optional[datetime] = None
+
+
+class AgencyMemberRoleUpdate(BaseModel):
+    """Schema for updating member role."""
+    role: Literal["admin", "member"]  # Can't change to owner via API
+
+
+# ============================================
+# Agency Invitation Schemas
+# ============================================
+
+class AgencyInviteRequest(BaseModel):
+    """Schema for inviting a creator to agency."""
+    email: EmailStr
+    role: AgencyMemberRole = "member"
+
+
+class AgencyInvitationResponse(BaseModel):
+    """Agency invitation response schema."""
+    id: UUID
+    agency_id: UUID
+    email: str
+    status: AgencyInvitationStatus
+    invited_by: UUID
+    expires_at: datetime
+    accepted_at: Optional[datetime] = None
+    created_at: datetime
+
+    # Agency info (populated via join)
+    agency_name: Optional[str] = None
+    agency_logo_url: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class AgencyInvitationListResponse(BaseModel):
+    """Simplified invitation list response."""
+    id: UUID
+    email: str
+    status: AgencyInvitationStatus
+    expires_at: datetime
+    created_at: datetime
+
+
+# ============================================
+# Creator-side Agency Schemas
+# ============================================
+
+class CreatorAgencyResponse(BaseModel):
+    """Response for creator's current agency."""
+    agency_id: UUID
+    agency_name: str
+    agency_slug: str
+    agency_logo_url: Optional[str] = None
+    role: AgencyMemberRole
+    joined_at: Optional[datetime] = None
+
+
+class AgencyJoinRequest(BaseModel):
+    """Schema for creator requesting to join agency."""
+    message: Optional[str] = Field(None, max_length=500)
+
+
+class PendingInvitationResponse(BaseModel):
+    """Pending invitation for creator."""
+    id: UUID
+    agency_id: UUID
+    agency_name: str
+    agency_logo_url: Optional[str] = None
+    invited_at: datetime
+    expires_at: datetime
+
+
+# ============================================
+# Agency Search Schemas
+# ============================================
+
+class AgencySearchParams(BaseModel):
+    """Parameters for searching agencies."""
+    q: str = Field(..., min_length=1, max_length=100)
+    limit: int = Field(default=10, ge=1, le=50)

--- a/backend/app/schemas/agency_opportunity.py
+++ b/backend/app/schemas/agency_opportunity.py
@@ -1,0 +1,197 @@
+"""
+Agency opportunity schemas for request/response validation.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
+
+
+# Type aliases
+OpportunityStatus = Literal["draft", "sent", "viewed", "accepted", "declined", "completed", "cancelled"]
+CompensationType = Literal["flat_fee", "cpm", "hybrid", "product_only"]
+
+
+# ============================================
+# Compensation & Requirements Schemas
+# ============================================
+
+class OpportunityRequirements(BaseModel):
+    """Structured requirements for an opportunity."""
+    deliverables: List[str] = Field(default_factory=list)
+    content_guidelines: Optional[str] = None
+    talking_points: List[str] = Field(default_factory=list)
+    restrictions: List[str] = Field(default_factory=list)
+
+
+class OpportunityCompensation(BaseModel):
+    """Structured compensation for an opportunity."""
+    type: CompensationType = "flat_fee"
+    amount: Optional[float] = None
+    currency: str = "USD"
+    payment_terms: Optional[str] = None
+    product_value: Optional[float] = None
+    notes: Optional[str] = None
+
+
+# ============================================
+# Agency Opportunity Schemas
+# ============================================
+
+class AgencyOpportunityCreate(BaseModel):
+    """Schema for creating an agency opportunity."""
+    creator_id: UUID
+    title: str = Field(..., min_length=1, max_length=255)
+    brand_name: str = Field(..., min_length=1, max_length=255)
+    brand_logo_url: Optional[str] = Field(None, max_length=500)
+    description: str = Field(..., min_length=1)
+
+    requirements: OpportunityRequirements = Field(default_factory=OpportunityRequirements)
+    compensation: OpportunityCompensation = Field(default_factory=OpportunityCompensation)
+
+    deadline: Optional[datetime] = None
+    content_deadline: Optional[datetime] = None
+
+    @field_validator('brand_logo_url', mode='before')
+    @classmethod
+    def empty_str_to_none(cls, v):
+        if v == '' or v is None:
+            return None
+        return v
+
+
+class AgencyOpportunityUpdate(BaseModel):
+    """Schema for updating an agency opportunity."""
+    title: Optional[str] = Field(None, min_length=1, max_length=255)
+    brand_name: Optional[str] = Field(None, min_length=1, max_length=255)
+    brand_logo_url: Optional[str] = Field(None, max_length=500)
+    description: Optional[str] = None
+
+    requirements: Optional[OpportunityRequirements] = None
+    compensation: Optional[OpportunityCompensation] = None
+
+    deadline: Optional[datetime] = None
+    content_deadline: Optional[datetime] = None
+
+    @field_validator('brand_logo_url', mode='before')
+    @classmethod
+    def empty_str_to_none(cls, v):
+        if v == '' or v is None:
+            return None
+        return v
+
+
+class AgencyOpportunityResponse(BaseModel):
+    """Agency opportunity response schema."""
+    id: UUID
+    agency_id: UUID
+    creator_id: UUID
+    created_by: UUID
+
+    title: str
+    brand_name: str
+    brand_logo_url: Optional[str] = None
+    description: str
+
+    requirements: Dict[str, Any] = {}
+    compensation: Dict[str, Any] = {}
+
+    deadline: Optional[datetime] = None
+    content_deadline: Optional[datetime] = None
+
+    status: OpportunityStatus
+    sent_at: Optional[datetime] = None
+    viewed_at: Optional[datetime] = None
+    creator_response_at: Optional[datetime] = None
+    creator_notes: Optional[str] = None
+
+    project_id: Optional[UUID] = None
+
+    created_at: datetime
+    updated_at: datetime
+
+    # Creator info (populated via join)
+    creator_email: Optional[str] = None
+    creator_full_name: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class AgencyOpportunityListResponse(BaseModel):
+    """Simplified opportunity list response."""
+    id: UUID
+    creator_id: UUID
+    title: str
+    brand_name: str
+    status: OpportunityStatus
+    deadline: Optional[datetime] = None
+    sent_at: Optional[datetime] = None
+    creator_full_name: Optional[str] = None
+    created_at: datetime
+
+
+# ============================================
+# Creator-side Opportunity Schemas
+# ============================================
+
+class CreatorOpportunityResponse(BaseModel):
+    """Opportunity response for creator view."""
+    id: UUID
+    agency_id: UUID
+    agency_name: str
+    agency_logo_url: Optional[str] = None
+
+    title: str
+    brand_name: str
+    brand_logo_url: Optional[str] = None
+    description: str
+
+    requirements: Dict[str, Any] = {}
+    compensation: Dict[str, Any] = {}
+
+    deadline: Optional[datetime] = None
+    content_deadline: Optional[datetime] = None
+
+    status: OpportunityStatus
+    sent_at: Optional[datetime] = None
+    viewed_at: Optional[datetime] = None
+
+    project_id: Optional[UUID] = None
+
+    created_at: datetime
+
+
+class CreatorOpportunityListResponse(BaseModel):
+    """Simplified opportunity list for creator."""
+    id: UUID
+    agency_name: str
+    title: str
+    brand_name: str
+    status: OpportunityStatus
+    deadline: Optional[datetime] = None
+    sent_at: Optional[datetime] = None
+
+
+class OpportunityAcceptRequest(BaseModel):
+    """Schema for accepting an opportunity."""
+    notes: Optional[str] = Field(None, max_length=1000)
+
+
+class OpportunityDeclineRequest(BaseModel):
+    """Schema for declining an opportunity."""
+    reason: Optional[str] = Field(None, max_length=1000)
+
+
+# ============================================
+# Opportunity Filter Schemas
+# ============================================
+
+class OpportunityFilters(BaseModel):
+    """Filters for listing opportunities."""
+    status: Optional[OpportunityStatus] = None
+    creator_id: Optional[UUID] = None
+    limit: int = Field(default=50, ge=1, le=100)
+    offset: int = Field(default=0, ge=0)

--- a/backend/app/services/agency_opportunity_service.py
+++ b/backend/app/services/agency_opportunity_service.py
@@ -1,0 +1,431 @@
+"""
+Agency opportunity service for managing sponsorship opportunities.
+"""
+
+from datetime import datetime
+from typing import Dict, List, Optional, Any
+from uuid import UUID
+
+from loguru import logger
+from sqlalchemy import select, func, and_, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.agency import Agency
+from app.models.agency_opportunity import AgencyOpportunity
+from app.models.user import User
+
+
+class AgencyOpportunityService:
+    """Service for agency opportunity management operations."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    # ============================================
+    # Create Operations
+    # ============================================
+
+    async def create_opportunity(
+        self,
+        agency_id: UUID,
+        creator_id: UUID,
+        created_by: UUID,
+        title: str,
+        brand_name: str,
+        description: str,
+        requirements: Dict[str, Any] = None,
+        compensation: Dict[str, Any] = None,
+        brand_logo_url: Optional[str] = None,
+        deadline: Optional[datetime] = None,
+        content_deadline: Optional[datetime] = None,
+        send_immediately: bool = False,
+    ) -> AgencyOpportunity:
+        """
+        Create a new agency opportunity.
+
+        Args:
+            agency_id: The agency creating the opportunity
+            creator_id: The target creator
+            created_by: The agency user creating this
+            title: Opportunity title
+            brand_name: Brand/sponsor name
+            description: Detailed description
+            requirements: Deliverables and requirements dict
+            compensation: Payment terms dict
+            brand_logo_url: Optional brand logo URL
+            deadline: Optional response deadline
+            content_deadline: Optional content delivery deadline
+            send_immediately: Whether to send immediately or keep as draft
+
+        Returns:
+            AgencyOpportunity: The created opportunity
+        """
+        opportunity = AgencyOpportunity(
+            agency_id=agency_id,
+            creator_id=creator_id,
+            created_by=created_by,
+            title=title,
+            brand_name=brand_name,
+            description=description,
+            requirements=requirements or {},
+            compensation=compensation or {},
+            brand_logo_url=brand_logo_url,
+            deadline=deadline,
+            content_deadline=content_deadline,
+            status="sent" if send_immediately else "draft",
+            sent_at=datetime.utcnow() if send_immediately else None,
+        )
+
+        self.db.add(opportunity)
+        await self.db.commit()
+        await self.db.refresh(opportunity)
+
+        logger.info(f"Opportunity created: {opportunity.title} (id={opportunity.id}, creator={creator_id})")
+        return opportunity
+
+    # ============================================
+    # Read Operations
+    # ============================================
+
+    async def get_by_id(self, opportunity_id: UUID) -> Optional[AgencyOpportunity]:
+        """Get opportunity by ID."""
+        result = await self.db.execute(
+            select(AgencyOpportunity)
+            .options(
+                selectinload(AgencyOpportunity.agency),
+                selectinload(AgencyOpportunity.creator),
+            )
+            .where(AgencyOpportunity.id == opportunity_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_agency(
+        self,
+        agency_id: UUID,
+        status: Optional[str] = None,
+        creator_id: Optional[UUID] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[AgencyOpportunity]:
+        """Get opportunities for an agency with optional filters."""
+        query = (
+            select(AgencyOpportunity)
+            .options(selectinload(AgencyOpportunity.creator))
+            .where(AgencyOpportunity.agency_id == agency_id)
+        )
+
+        if status:
+            query = query.where(AgencyOpportunity.status == status)
+        if creator_id:
+            query = query.where(AgencyOpportunity.creator_id == creator_id)
+
+        query = query.order_by(AgencyOpportunity.created_at.desc())
+        query = query.limit(limit).offset(offset)
+
+        result = await self.db.execute(query)
+        return list(result.scalars().all())
+
+    async def get_by_creator(
+        self,
+        creator_id: UUID,
+        status: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[AgencyOpportunity]:
+        """Get opportunities for a creator with optional filters."""
+        query = (
+            select(AgencyOpportunity)
+            .options(selectinload(AgencyOpportunity.agency))
+            .where(
+                AgencyOpportunity.creator_id == creator_id,
+                # Only show sent opportunities to creators (not drafts)
+                AgencyOpportunity.status != "draft",
+            )
+        )
+
+        if status:
+            query = query.where(AgencyOpportunity.status == status)
+
+        query = query.order_by(AgencyOpportunity.sent_at.desc().nulls_last())
+        query = query.limit(limit).offset(offset)
+
+        result = await self.db.execute(query)
+        return list(result.scalars().all())
+
+    async def count_by_agency(
+        self,
+        agency_id: UUID,
+        status: Optional[str] = None,
+    ) -> int:
+        """Count opportunities for an agency."""
+        query = select(func.count(AgencyOpportunity.id)).where(
+            AgencyOpportunity.agency_id == agency_id
+        )
+        if status:
+            query = query.where(AgencyOpportunity.status == status)
+
+        result = await self.db.execute(query)
+        return result.scalar() or 0
+
+    async def count_by_creator(
+        self,
+        creator_id: UUID,
+        status: Optional[str] = None,
+    ) -> int:
+        """Count opportunities for a creator (excluding drafts)."""
+        query = select(func.count(AgencyOpportunity.id)).where(
+            AgencyOpportunity.creator_id == creator_id,
+            AgencyOpportunity.status != "draft",
+        )
+        if status:
+            query = query.where(AgencyOpportunity.status == status)
+
+        result = await self.db.execute(query)
+        return result.scalar() or 0
+
+    async def get_pending_for_creator(self, creator_id: UUID) -> List[AgencyOpportunity]:
+        """Get pending (sent but not responded) opportunities for a creator."""
+        result = await self.db.execute(
+            select(AgencyOpportunity)
+            .options(selectinload(AgencyOpportunity.agency))
+            .where(
+                AgencyOpportunity.creator_id == creator_id,
+                AgencyOpportunity.status.in_(["sent", "viewed"]),
+            )
+            .order_by(AgencyOpportunity.sent_at.desc())
+        )
+        return list(result.scalars().all())
+
+    # ============================================
+    # Update Operations
+    # ============================================
+
+    async def update_opportunity(
+        self,
+        opportunity_id: UUID,
+        **updates
+    ) -> Optional[AgencyOpportunity]:
+        """Update opportunity details (only drafts can be fully edited)."""
+        opportunity = await self.get_by_id(opportunity_id)
+        if not opportunity:
+            return None
+
+        for key, value in updates.items():
+            if hasattr(opportunity, key) and value is not None:
+                setattr(opportunity, key, value)
+
+        opportunity.updated_at = datetime.utcnow()
+        await self.db.commit()
+        await self.db.refresh(opportunity)
+
+        logger.info(f"Opportunity updated: {opportunity.title} (id={opportunity_id})")
+        return opportunity
+
+    async def send_opportunity(self, opportunity_id: UUID) -> Optional[AgencyOpportunity]:
+        """Send a draft opportunity to the creator."""
+        opportunity = await self.get_by_id(opportunity_id)
+        if not opportunity:
+            return None
+
+        if opportunity.status != "draft":
+            logger.warning(f"Cannot send non-draft opportunity: {opportunity_id}")
+            return None
+
+        opportunity.status = "sent"
+        opportunity.sent_at = datetime.utcnow()
+        opportunity.updated_at = datetime.utcnow()
+
+        await self.db.commit()
+        await self.db.refresh(opportunity)
+
+        logger.info(f"Opportunity sent: {opportunity.title} (id={opportunity_id})")
+        return opportunity
+
+    async def mark_as_viewed(self, opportunity_id: UUID) -> Optional[AgencyOpportunity]:
+        """Mark opportunity as viewed by creator."""
+        opportunity = await self.get_by_id(opportunity_id)
+        if not opportunity:
+            return None
+
+        if opportunity.status == "sent":
+            opportunity.status = "viewed"
+            opportunity.viewed_at = datetime.utcnow()
+            opportunity.updated_at = datetime.utcnow()
+            await self.db.commit()
+            await self.db.refresh(opportunity)
+
+        return opportunity
+
+    async def accept_opportunity(
+        self,
+        opportunity_id: UUID,
+        creator_notes: Optional[str] = None,
+    ) -> Optional[AgencyOpportunity]:
+        """
+        Accept an opportunity.
+
+        Args:
+            opportunity_id: The opportunity to accept
+            creator_notes: Optional notes from creator
+
+        Returns:
+            Updated opportunity or None if not found
+        """
+        opportunity = await self.get_by_id(opportunity_id)
+        if not opportunity:
+            return None
+
+        if opportunity.status not in ["sent", "viewed"]:
+            logger.warning(f"Cannot accept opportunity in status {opportunity.status}")
+            return None
+
+        opportunity.status = "accepted"
+        opportunity.creator_response_at = datetime.utcnow()
+        opportunity.creator_notes = creator_notes
+        opportunity.updated_at = datetime.utcnow()
+
+        await self.db.commit()
+        await self.db.refresh(opportunity)
+
+        logger.info(f"Opportunity accepted: {opportunity.title} (id={opportunity_id})")
+        return opportunity
+
+    async def decline_opportunity(
+        self,
+        opportunity_id: UUID,
+        reason: Optional[str] = None,
+    ) -> Optional[AgencyOpportunity]:
+        """
+        Decline an opportunity.
+
+        Args:
+            opportunity_id: The opportunity to decline
+            reason: Optional reason for declining
+
+        Returns:
+            Updated opportunity or None if not found
+        """
+        opportunity = await self.get_by_id(opportunity_id)
+        if not opportunity:
+            return None
+
+        if opportunity.status not in ["sent", "viewed"]:
+            logger.warning(f"Cannot decline opportunity in status {opportunity.status}")
+            return None
+
+        opportunity.status = "declined"
+        opportunity.creator_response_at = datetime.utcnow()
+        opportunity.creator_notes = reason
+        opportunity.updated_at = datetime.utcnow()
+
+        await self.db.commit()
+        await self.db.refresh(opportunity)
+
+        logger.info(f"Opportunity declined: {opportunity.title} (id={opportunity_id})")
+        return opportunity
+
+    async def complete_opportunity(
+        self,
+        opportunity_id: UUID,
+    ) -> Optional[AgencyOpportunity]:
+        """Mark an accepted opportunity as completed."""
+        opportunity = await self.get_by_id(opportunity_id)
+        if not opportunity:
+            return None
+
+        if opportunity.status != "accepted":
+            logger.warning(f"Cannot complete opportunity in status {opportunity.status}")
+            return None
+
+        opportunity.status = "completed"
+        opportunity.updated_at = datetime.utcnow()
+
+        await self.db.commit()
+        await self.db.refresh(opportunity)
+
+        logger.info(f"Opportunity completed: {opportunity.title} (id={opportunity_id})")
+        return opportunity
+
+    async def cancel_opportunity(
+        self,
+        opportunity_id: UUID,
+    ) -> Optional[AgencyOpportunity]:
+        """Cancel an opportunity (agency action)."""
+        opportunity = await self.get_by_id(opportunity_id)
+        if not opportunity:
+            return None
+
+        if opportunity.status in ["completed", "cancelled"]:
+            logger.warning(f"Cannot cancel opportunity in status {opportunity.status}")
+            return None
+
+        opportunity.status = "cancelled"
+        opportunity.updated_at = datetime.utcnow()
+
+        await self.db.commit()
+        await self.db.refresh(opportunity)
+
+        logger.info(f"Opportunity cancelled: {opportunity.title} (id={opportunity_id})")
+        return opportunity
+
+    async def link_project(
+        self,
+        opportunity_id: UUID,
+        project_id: UUID,
+    ) -> Optional[AgencyOpportunity]:
+        """Link a monetization project to an accepted opportunity."""
+        opportunity = await self.get_by_id(opportunity_id)
+        if not opportunity:
+            return None
+
+        opportunity.project_id = project_id
+        opportunity.updated_at = datetime.utcnow()
+
+        await self.db.commit()
+        await self.db.refresh(opportunity)
+
+        logger.info(f"Project linked to opportunity: opportunity={opportunity_id}, project={project_id}")
+        return opportunity
+
+    # ============================================
+    # Delete Operations
+    # ============================================
+
+    async def delete_opportunity(self, opportunity_id: UUID) -> bool:
+        """Delete a draft opportunity."""
+        opportunity = await self.get_by_id(opportunity_id)
+        if not opportunity:
+            return False
+
+        if opportunity.status != "draft":
+            logger.warning(f"Cannot delete non-draft opportunity: {opportunity_id}")
+            return False
+
+        await self.db.delete(opportunity)
+        await self.db.commit()
+
+        logger.info(f"Opportunity deleted: {opportunity_id}")
+        return True
+
+    # ============================================
+    # Stats
+    # ============================================
+
+    async def get_agency_stats(self, agency_id: UUID) -> Dict[str, int]:
+        """Get opportunity statistics for an agency."""
+        # Count by status
+        statuses = ["draft", "sent", "viewed", "accepted", "declined", "completed", "cancelled"]
+        stats = {}
+
+        for status in statuses:
+            count = await self.count_by_agency(agency_id, status=status)
+            stats[status] = count
+
+        # Total
+        stats["total"] = sum(stats.values())
+
+        # Active (sent + viewed)
+        stats["active"] = stats["sent"] + stats["viewed"]
+
+        return stats

--- a/backend/app/services/agency_service.py
+++ b/backend/app/services/agency_service.py
@@ -1,0 +1,550 @@
+"""
+Agency service for managing agencies and their operations.
+"""
+
+import re
+import secrets
+from datetime import datetime, timedelta
+from typing import List, Optional
+from uuid import UUID
+
+from loguru import logger
+from sqlalchemy import select, func, and_, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.agency import Agency, AgencyMember, AgencyInvitation
+from app.models.user import User
+
+
+class AgencyService:
+    """Service for agency management operations."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    # ============================================
+    # Agency CRUD Operations
+    # ============================================
+
+    async def create_agency(
+        self,
+        name: str,
+        owner_id: UUID,
+        website: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> Agency:
+        """
+        Create a new agency and set the owner as an agency member.
+
+        Args:
+            name: Agency display name
+            owner_id: User ID of the agency owner
+            website: Optional agency website
+            description: Optional agency description
+
+        Returns:
+            Agency: The created agency
+        """
+        # Generate unique slug
+        slug = await self._generate_unique_slug(name)
+
+        # Create agency
+        agency = Agency(
+            name=name,
+            slug=slug,
+            owner_id=owner_id,
+            website=website,
+            description=description,
+            settings={},
+            is_active=True,
+        )
+        self.db.add(agency)
+        await self.db.flush()
+
+        # Create owner membership
+        owner_member = AgencyMember(
+            agency_id=agency.id,
+            user_id=owner_id,
+            role="owner",
+            status="active",
+            joined_at=datetime.utcnow(),
+        )
+        self.db.add(owner_member)
+
+        await self.db.commit()
+        await self.db.refresh(agency)
+
+        logger.info(f"Agency created: {agency.name} (slug={agency.slug}, owner_id={owner_id})")
+        return agency
+
+    async def get_by_id(self, agency_id: UUID) -> Optional[Agency]:
+        """Get agency by ID."""
+        result = await self.db.execute(
+            select(Agency).where(Agency.id == agency_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_slug(self, slug: str) -> Optional[Agency]:
+        """Get agency by slug."""
+        result = await self.db.execute(
+            select(Agency).where(Agency.slug == slug)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_owner(self, owner_id: UUID) -> Optional[Agency]:
+        """Get agency owned by a specific user."""
+        result = await self.db.execute(
+            select(Agency).where(Agency.owner_id == owner_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def update_agency(
+        self,
+        agency_id: UUID,
+        **updates
+    ) -> Optional[Agency]:
+        """Update agency details."""
+        agency = await self.get_by_id(agency_id)
+        if not agency:
+            return None
+
+        for key, value in updates.items():
+            if hasattr(agency, key) and value is not None:
+                setattr(agency, key, value)
+
+        agency.updated_at = datetime.utcnow()
+        await self.db.commit()
+        await self.db.refresh(agency)
+
+        logger.info(f"Agency updated: {agency.name} (id={agency_id})")
+        return agency
+
+    async def search_agencies(
+        self,
+        query: str,
+        limit: int = 10
+    ) -> List[Agency]:
+        """Search agencies by name (for creators to find agencies)."""
+        result = await self.db.execute(
+            select(Agency)
+            .where(
+                and_(
+                    Agency.is_active == True,
+                    Agency.name.ilike(f"%{query}%")
+                )
+            )
+            .order_by(Agency.name)
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+    # ============================================
+    # Membership Operations
+    # ============================================
+
+    async def get_user_agency_membership(
+        self,
+        user_id: UUID
+    ) -> Optional[AgencyMember]:
+        """Get user's active agency membership (if any)."""
+        result = await self.db.execute(
+            select(AgencyMember)
+            .options(selectinload(AgencyMember.agency))
+            .where(
+                and_(
+                    AgencyMember.user_id == user_id,
+                    AgencyMember.status == "active"
+                )
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_agency_members(
+        self,
+        agency_id: UUID,
+        status: Optional[str] = None,
+        role: Optional[str] = None,
+    ) -> List[AgencyMember]:
+        """Get all members of an agency."""
+        query = select(AgencyMember).options(
+            selectinload(AgencyMember.user)
+        ).where(AgencyMember.agency_id == agency_id)
+
+        if status:
+            query = query.where(AgencyMember.status == status)
+        if role:
+            query = query.where(AgencyMember.role == role)
+
+        result = await self.db.execute(query.order_by(AgencyMember.created_at))
+        return list(result.scalars().all())
+
+    async def get_agency_creators(self, agency_id: UUID) -> List[User]:
+        """Get all creators (non-team members) linked to an agency."""
+        result = await self.db.execute(
+            select(User)
+            .where(
+                and_(
+                    User.agency_id == agency_id,
+                    User.account_type == "creator"
+                )
+            )
+            .order_by(User.full_name)
+        )
+        return list(result.scalars().all())
+
+    async def get_agency_creator_count(self, agency_id: UUID) -> int:
+        """Get count of creators linked to an agency."""
+        result = await self.db.execute(
+            select(func.count(User.id))
+            .where(
+                and_(
+                    User.agency_id == agency_id,
+                    User.account_type == "creator"
+                )
+            )
+        )
+        return result.scalar() or 0
+
+    async def check_user_can_join_agency(self, user_id: UUID) -> bool:
+        """Check if user can join an agency (not already in one)."""
+        user = await self.db.get(User, user_id)
+        if not user:
+            return False
+
+        # Check if user already has an agency
+        if user.agency_id:
+            return False
+
+        # Check for any active memberships
+        existing = await self.get_user_agency_membership(user_id)
+        return existing is None
+
+    async def add_member(
+        self,
+        agency_id: UUID,
+        user_id: UUID,
+        role: str = "member",
+        status: str = "pending_invite",
+        invited_by: Optional[UUID] = None,
+    ) -> AgencyMember:
+        """Add a member to an agency."""
+        member = AgencyMember(
+            agency_id=agency_id,
+            user_id=user_id,
+            role=role,
+            status=status,
+            invited_by=invited_by,
+            invited_at=datetime.utcnow() if status == "pending_invite" else None,
+        )
+        self.db.add(member)
+        await self.db.commit()
+        await self.db.refresh(member)
+
+        logger.info(f"Member added to agency: user_id={user_id}, agency_id={agency_id}, role={role}")
+        return member
+
+    async def update_member_status(
+        self,
+        member_id: UUID,
+        new_status: str,
+    ) -> Optional[AgencyMember]:
+        """Update a member's status."""
+        result = await self.db.execute(
+            select(AgencyMember).where(AgencyMember.id == member_id)
+        )
+        member = result.scalar_one_or_none()
+        if not member:
+            return None
+
+        member.status = new_status
+        if new_status == "active":
+            member.joined_at = datetime.utcnow()
+
+        member.updated_at = datetime.utcnow()
+        await self.db.commit()
+        await self.db.refresh(member)
+
+        return member
+
+    async def update_member_role(
+        self,
+        member_id: UUID,
+        new_role: str,
+    ) -> Optional[AgencyMember]:
+        """Update a member's role."""
+        result = await self.db.execute(
+            select(AgencyMember).where(AgencyMember.id == member_id)
+        )
+        member = result.scalar_one_or_none()
+        if not member:
+            return None
+
+        member.role = new_role
+        member.updated_at = datetime.utcnow()
+        await self.db.commit()
+        await self.db.refresh(member)
+
+        logger.info(f"Member role updated: member_id={member_id}, new_role={new_role}")
+        return member
+
+    async def remove_member(self, member_id: UUID) -> bool:
+        """Remove a member from an agency."""
+        result = await self.db.execute(
+            select(AgencyMember).where(AgencyMember.id == member_id)
+        )
+        member = result.scalar_one_or_none()
+        if not member:
+            return False
+
+        # Update status to removed
+        member.status = "removed"
+        member.updated_at = datetime.utcnow()
+
+        # Also clear the user's agency_id if they're a creator
+        user = await self.db.get(User, member.user_id)
+        if user and user.agency_id == member.agency_id:
+            user.agency_id = None
+
+        await self.db.commit()
+
+        logger.info(f"Member removed from agency: member_id={member_id}")
+        return True
+
+    async def link_creator_to_agency(
+        self,
+        user_id: UUID,
+        agency_id: UUID,
+    ) -> bool:
+        """Link a creator to an agency (set user.agency_id)."""
+        user = await self.db.get(User, user_id)
+        if not user:
+            return False
+
+        user.agency_id = agency_id
+        await self.db.commit()
+
+        logger.info(f"Creator linked to agency: user_id={user_id}, agency_id={agency_id}")
+        return True
+
+    async def unlink_creator_from_agency(self, user_id: UUID) -> bool:
+        """Remove a creator's agency link."""
+        user = await self.db.get(User, user_id)
+        if not user:
+            return False
+
+        user.agency_id = None
+        await self.db.commit()
+
+        logger.info(f"Creator unlinked from agency: user_id={user_id}")
+        return True
+
+    # ============================================
+    # Invitation Operations
+    # ============================================
+
+    async def create_invitation(
+        self,
+        agency_id: UUID,
+        email: str,
+        invited_by: UUID,
+        expires_in_days: int = 7,
+    ) -> AgencyInvitation:
+        """Create an invitation for a non-user to join an agency."""
+        token = secrets.token_urlsafe(32)
+        expires_at = datetime.utcnow() + timedelta(days=expires_in_days)
+
+        invitation = AgencyInvitation(
+            agency_id=agency_id,
+            email=email.lower(),
+            token=token,
+            invited_by=invited_by,
+            expires_at=expires_at,
+            status="pending",
+        )
+        self.db.add(invitation)
+        await self.db.commit()
+        await self.db.refresh(invitation)
+
+        logger.info(f"Invitation created: email={email}, agency_id={agency_id}")
+        return invitation
+
+    async def get_invitation_by_token(self, token: str) -> Optional[AgencyInvitation]:
+        """Get an invitation by its token."""
+        result = await self.db.execute(
+            select(AgencyInvitation)
+            .options(selectinload(AgencyInvitation.agency))
+            .where(AgencyInvitation.token == token)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_invitation_by_id(self, invitation_id: UUID) -> Optional[AgencyInvitation]:
+        """Get an invitation by ID."""
+        result = await self.db.execute(
+            select(AgencyInvitation)
+            .options(selectinload(AgencyInvitation.agency))
+            .where(AgencyInvitation.id == invitation_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_pending_invitations_for_email(self, email: str) -> List[AgencyInvitation]:
+        """Get all pending invitations for an email address."""
+        result = await self.db.execute(
+            select(AgencyInvitation)
+            .options(selectinload(AgencyInvitation.agency))
+            .where(
+                and_(
+                    AgencyInvitation.email == email.lower(),
+                    AgencyInvitation.status == "pending",
+                    AgencyInvitation.expires_at > datetime.utcnow()
+                )
+            )
+            .order_by(AgencyInvitation.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def get_agency_invitations(
+        self,
+        agency_id: UUID,
+        status: Optional[str] = None,
+    ) -> List[AgencyInvitation]:
+        """Get all invitations for an agency."""
+        query = select(AgencyInvitation).where(
+            AgencyInvitation.agency_id == agency_id
+        )
+        if status:
+            query = query.where(AgencyInvitation.status == status)
+
+        result = await self.db.execute(query.order_by(AgencyInvitation.created_at.desc()))
+        return list(result.scalars().all())
+
+    async def accept_invitation(self, invitation_id: UUID) -> Optional[AgencyInvitation]:
+        """Mark an invitation as accepted."""
+        invitation = await self.get_invitation_by_id(invitation_id)
+        if not invitation:
+            return None
+
+        invitation.status = "accepted"
+        invitation.accepted_at = datetime.utcnow()
+        invitation.updated_at = datetime.utcnow()
+
+        await self.db.commit()
+        await self.db.refresh(invitation)
+
+        return invitation
+
+    async def cancel_invitation(self, invitation_id: UUID) -> bool:
+        """Cancel a pending invitation."""
+        invitation = await self.get_invitation_by_id(invitation_id)
+        if not invitation or invitation.status != "pending":
+            return False
+
+        invitation.status = "cancelled"
+        invitation.updated_at = datetime.utcnow()
+
+        await self.db.commit()
+        return True
+
+    # ============================================
+    # Join Request Operations
+    # ============================================
+
+    async def create_join_request(
+        self,
+        agency_id: UUID,
+        user_id: UUID,
+    ) -> AgencyMember:
+        """Create a join request from a creator to an agency."""
+        member = AgencyMember(
+            agency_id=agency_id,
+            user_id=user_id,
+            role="member",
+            status="pending_request",
+        )
+        self.db.add(member)
+        await self.db.commit()
+        await self.db.refresh(member)
+
+        logger.info(f"Join request created: user_id={user_id}, agency_id={agency_id}")
+        return member
+
+    async def get_pending_join_requests(self, agency_id: UUID) -> List[AgencyMember]:
+        """Get all pending join requests for an agency."""
+        return await self.get_agency_members(agency_id, status="pending_request")
+
+    async def accept_join_request(self, member_id: UUID) -> Optional[AgencyMember]:
+        """Accept a join request."""
+        member = await self.update_member_status(member_id, "active")
+        if member:
+            # Also link the creator to the agency
+            await self.link_creator_to_agency(member.user_id, member.agency_id)
+        return member
+
+    async def reject_join_request(self, member_id: UUID) -> bool:
+        """Reject a join request."""
+        result = await self.db.execute(
+            select(AgencyMember).where(AgencyMember.id == member_id)
+        )
+        member = result.scalar_one_or_none()
+        if not member or member.status != "pending_request":
+            return False
+
+        # Delete the request entirely
+        await self.db.delete(member)
+        await self.db.commit()
+
+        logger.info(f"Join request rejected: member_id={member_id}")
+        return True
+
+    # ============================================
+    # Helper Methods
+    # ============================================
+
+    async def _generate_unique_slug(self, name: str) -> str:
+        """Generate a unique slug from agency name."""
+        # Convert to lowercase and replace spaces/special chars with hyphens
+        base_slug = re.sub(r'[^a-z0-9]+', '-', name.lower()).strip('-')
+
+        # Check if slug exists
+        slug = base_slug
+        counter = 1
+
+        while True:
+            result = await self.db.execute(
+                select(Agency).where(Agency.slug == slug)
+            )
+            if not result.scalar_one_or_none():
+                break
+            slug = f"{base_slug}-{counter}"
+            counter += 1
+
+        return slug
+
+    async def is_user_agency_admin(self, user_id: UUID, agency_id: UUID) -> bool:
+        """Check if user is an admin (owner or admin role) of the agency."""
+        result = await self.db.execute(
+            select(AgencyMember)
+            .where(
+                and_(
+                    AgencyMember.agency_id == agency_id,
+                    AgencyMember.user_id == user_id,
+                    AgencyMember.status == "active",
+                    AgencyMember.role.in_(["owner", "admin"])
+                )
+            )
+        )
+        return result.scalar_one_or_none() is not None
+
+    async def is_user_agency_member(self, user_id: UUID, agency_id: UUID) -> bool:
+        """Check if user is any kind of member of the agency."""
+        result = await self.db.execute(
+            select(AgencyMember)
+            .where(
+                and_(
+                    AgencyMember.agency_id == agency_id,
+                    AgencyMember.user_id == user_id,
+                    AgencyMember.status == "active"
+                )
+            )
+        )
+        return result.scalar_one_or_none() is not None

--- a/frontend/app/(agency)/agency/creators/page.tsx
+++ b/frontend/app/(agency)/agency/creators/page.tsx
@@ -1,0 +1,446 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import {
+  Users,
+  UserPlus,
+  Search,
+  Mail,
+  MoreVertical,
+  Trash2,
+  CheckCircle,
+  XCircle,
+  Clock,
+  Loader2,
+} from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/tabs';
+import { Label } from '@/components/ui/label';
+import { agencyApi, type AgencyCreator, type AgencyMember, type AgencyInvitation } from '@/lib/agency-api';
+import { toast } from 'sonner';
+
+export default function AgencyCreatorsPage() {
+  const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [isInviting, setIsInviting] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Data states
+  const [creators, setCreators] = useState<AgencyCreator[]>([]);
+  const [joinRequests, setJoinRequests] = useState<AgencyMember[]>([]);
+  const [invitations, setInvitations] = useState<AgencyInvitation[]>([]);
+
+  // Fetch data on mount
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const fetchData = async () => {
+    setIsLoading(true);
+    try {
+      const [creatorsData, requestsData, invitationsData] = await Promise.all([
+        agencyApi.getCreators(),
+        agencyApi.getJoinRequests(),
+        agencyApi.getInvitations('pending'),
+      ]);
+      setCreators(creatorsData);
+      setJoinRequests(requestsData);
+      setInvitations(invitationsData);
+    } catch (error) {
+      console.error('Failed to fetch data:', error);
+      toast.error('Failed to load creators');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleInvite = async () => {
+    if (!inviteEmail) return;
+
+    setIsInviting(true);
+    try {
+      await agencyApi.inviteCreator(inviteEmail);
+      toast.success('Invitation sent!');
+      setInviteEmail('');
+      setIsInviteModalOpen(false);
+      fetchData(); // Refresh data
+    } catch (error: unknown) {
+      const err = error as { response?: { data?: { detail?: string } } };
+      toast.error(err.response?.data?.detail || 'Failed to send invitation');
+    } finally {
+      setIsInviting(false);
+    }
+  };
+
+  const handleAcceptRequest = async (requestId: string) => {
+    try {
+      await agencyApi.acceptJoinRequest(requestId);
+      toast.success('Request accepted! Creator added to your agency.');
+      fetchData();
+    } catch (error) {
+      toast.error('Failed to accept request');
+    }
+  };
+
+  const handleRejectRequest = async (requestId: string) => {
+    try {
+      await agencyApi.rejectJoinRequest(requestId);
+      toast.success('Request rejected');
+      fetchData();
+    } catch (error) {
+      toast.error('Failed to reject request');
+    }
+  };
+
+  const handleCancelInvitation = async (invitationId: string) => {
+    try {
+      await agencyApi.cancelInvitation(invitationId);
+      toast.success('Invitation cancelled');
+      fetchData();
+    } catch (error) {
+      toast.error('Failed to cancel invitation');
+    }
+  };
+
+  const handleRemoveCreator = async (creatorId: string) => {
+    if (!confirm('Are you sure you want to remove this creator from your agency?')) {
+      return;
+    }
+    try {
+      await agencyApi.removeCreator(creatorId);
+      toast.success('Creator removed from agency');
+      fetchData();
+    } catch (error) {
+      toast.error('Failed to remove creator');
+    }
+  };
+
+  const filteredCreators = creators.filter(
+    (c) =>
+      c.full_name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      c.email.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Creators
+          </h1>
+          <p className="mt-1 text-gray-600 dark:text-gray-400">
+            Manage creators in your agency
+          </p>
+        </div>
+        <Dialog open={isInviteModalOpen} onOpenChange={setIsInviteModalOpen}>
+          <DialogTrigger asChild>
+            <Button className="bg-green-600 hover:bg-green-700">
+              <UserPlus className="mr-2 h-4 w-4" />
+              Invite Creator
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Invite a Creator</DialogTitle>
+              <DialogDescription>
+                Send an invitation to a creator to join your agency. They&apos;ll receive
+                an email with a link to accept.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4 py-4">
+              <div className="space-y-2">
+                <Label htmlFor="email">Creator&apos;s Email</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="creator@example.com"
+                  value={inviteEmail}
+                  onChange={(e) => setInviteEmail(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleInvite()}
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setIsInviteModalOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handleInvite}
+                disabled={!inviteEmail || isInviting}
+                className="bg-green-600 hover:bg-green-700"
+              >
+                {isInviting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Sending...
+                  </>
+                ) : (
+                  'Send Invitation'
+                )}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {/* Tabs */}
+      <Tabs defaultValue="creators">
+        <TabsList>
+          <TabsTrigger value="creators">
+            Creators ({creators.length})
+          </TabsTrigger>
+          <TabsTrigger value="requests">
+            Join Requests ({joinRequests.length})
+          </TabsTrigger>
+          <TabsTrigger value="invitations">
+            Pending Invites ({invitations.length})
+          </TabsTrigger>
+        </TabsList>
+
+        {/* Creators Tab */}
+        <TabsContent value="creators" className="space-y-4">
+          {/* Search */}
+          <div className="relative max-w-md">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <Input
+              placeholder="Search creators..."
+              className="pl-10"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </div>
+
+          {filteredCreators.length === 0 ? (
+            <Card className="border-dashed">
+              <CardContent className="py-12">
+                <div className="text-center">
+                  <div className="mx-auto h-16 w-16 rounded-full bg-green-50 dark:bg-green-900/20 flex items-center justify-center mb-4">
+                    <Users className="h-8 w-8 text-green-600 dark:text-green-400" />
+                  </div>
+                  <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                    {searchQuery ? 'No creators found' : 'No creators yet'}
+                  </h3>
+                  <p className="text-gray-600 dark:text-gray-400 max-w-md mx-auto mb-6">
+                    {searchQuery
+                      ? 'Try adjusting your search terms'
+                      : "Invite creators to join your agency. Once they accept, you'll be able to send them sponsorship opportunities."}
+                  </p>
+                  {!searchQuery && (
+                    <Button
+                      onClick={() => setIsInviteModalOpen(true)}
+                      className="bg-green-600 hover:bg-green-700"
+                    >
+                      <Mail className="mr-2 h-4 w-4" />
+                      Invite Your First Creator
+                    </Button>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid gap-4">
+              {filteredCreators.map((creator) => (
+                <Card key={creator.id}>
+                  <CardContent className="py-4">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-4">
+                        <div className="h-12 w-12 rounded-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center text-white font-medium text-lg">
+                          {(creator.full_name || creator.email).charAt(0).toUpperCase()}
+                        </div>
+                        <div>
+                          <h3 className="font-semibold text-gray-900 dark:text-gray-100">
+                            {creator.full_name || 'Unnamed Creator'}
+                          </h3>
+                          <p className="text-sm text-gray-500 dark:text-gray-400">
+                            {creator.email}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-4">
+                        <div className="text-right text-sm text-gray-500">
+                          Joined {new Date(creator.created_at).toLocaleDateString()}
+                        </div>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button variant="ghost" size="icon">
+                              <MoreVertical className="h-4 w-4" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              className="text-red-600"
+                              onClick={() => handleRemoveCreator(creator.id)}
+                            >
+                              <Trash2 className="mr-2 h-4 w-4" />
+                              Remove from Agency
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </TabsContent>
+
+        {/* Join Requests Tab */}
+        <TabsContent value="requests" className="space-y-4">
+          {joinRequests.length === 0 ? (
+            <Card className="border-dashed">
+              <CardContent className="py-12">
+                <div className="text-center">
+                  <div className="mx-auto h-16 w-16 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center mb-4">
+                    <Clock className="h-8 w-8 text-gray-400" />
+                  </div>
+                  <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                    No pending requests
+                  </h3>
+                  <p className="text-gray-600 dark:text-gray-400">
+                    When creators request to join your agency, they&apos;ll appear here.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid gap-4">
+              {joinRequests.map((request) => (
+                <Card key={request.id}>
+                  <CardContent className="py-4">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-4">
+                        <div className="h-12 w-12 rounded-full bg-gradient-to-br from-yellow-400 to-orange-500 flex items-center justify-center text-white font-medium text-lg">
+                          {(request.user_full_name || request.user_email).charAt(0).toUpperCase()}
+                        </div>
+                        <div>
+                          <h3 className="font-semibold text-gray-900 dark:text-gray-100">
+                            {request.user_full_name || 'Unnamed'}
+                          </h3>
+                          <p className="text-sm text-gray-500 dark:text-gray-400">
+                            {request.user_email}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="text-red-600 border-red-200 hover:bg-red-50"
+                          onClick={() => handleRejectRequest(request.id)}
+                        >
+                          <XCircle className="mr-1 h-4 w-4" />
+                          Decline
+                        </Button>
+                        <Button
+                          size="sm"
+                          className="bg-green-600 hover:bg-green-700"
+                          onClick={() => handleAcceptRequest(request.id)}
+                        >
+                          <CheckCircle className="mr-1 h-4 w-4" />
+                          Accept
+                        </Button>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </TabsContent>
+
+        {/* Pending Invitations Tab */}
+        <TabsContent value="invitations" className="space-y-4">
+          {invitations.length === 0 ? (
+            <Card className="border-dashed">
+              <CardContent className="py-12">
+                <div className="text-center">
+                  <div className="mx-auto h-16 w-16 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center mb-4">
+                    <Mail className="h-8 w-8 text-gray-400" />
+                  </div>
+                  <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                    No pending invitations
+                  </h3>
+                  <p className="text-gray-600 dark:text-gray-400">
+                    All your invitations have been responded to.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid gap-4">
+              {invitations.map((invitation) => (
+                <Card key={invitation.id}>
+                  <CardContent className="py-4">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-4">
+                        <div className="h-12 w-12 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-gray-500 font-medium text-lg">
+                          {invitation.email.charAt(0).toUpperCase()}
+                        </div>
+                        <div>
+                          <p className="font-medium text-gray-900 dark:text-gray-100">
+                            {invitation.email}
+                          </p>
+                          <p className="text-sm text-gray-500 dark:text-gray-400">
+                            Sent {new Date(invitation.created_at).toLocaleDateString()}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <Badge variant="secondary">
+                          <Clock className="mr-1 h-3 w-3" />
+                          Expires {new Date(invitation.expires_at).toLocaleDateString()}
+                        </Badge>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="text-red-600 hover:bg-red-50"
+                          onClick={() => handleCancelInvitation(invitation.id)}
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/app/(agency)/agency/opportunities/[id]/page.tsx
+++ b/frontend/app/(agency)/agency/opportunities/[id]/page.tsx
@@ -1,0 +1,827 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { LoadingSpinner } from '@/components/shared/LoadingSpinner';
+import {
+  ArrowLeft,
+  Save,
+  Send,
+  X,
+  CheckCircle,
+  Trash2,
+  Plus,
+  Clock,
+  Eye,
+  User,
+  Building2,
+  DollarSign,
+  FileText,
+  AlertTriangle,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  opportunityApi,
+  type AgencyOpportunity,
+  type OpportunityStatus,
+} from '@/lib/agency-api';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+
+const statusConfig: Record<OpportunityStatus, { label: string; color: string; icon: React.ReactNode }> = {
+  draft: { label: 'Draft', color: 'bg-gray-100 text-gray-700', icon: <FileText className="h-3 w-3" /> },
+  sent: { label: 'Sent', color: 'bg-blue-100 text-blue-700', icon: <Send className="h-3 w-3" /> },
+  viewed: { label: 'Viewed', color: 'bg-purple-100 text-purple-700', icon: <Eye className="h-3 w-3" /> },
+  accepted: { label: 'Accepted', color: 'bg-green-100 text-green-700', icon: <CheckCircle className="h-3 w-3" /> },
+  declined: { label: 'Declined', color: 'bg-red-100 text-red-700', icon: <X className="h-3 w-3" /> },
+  completed: { label: 'Completed', color: 'bg-emerald-100 text-emerald-700', icon: <CheckCircle className="h-3 w-3" /> },
+  cancelled: { label: 'Cancelled', color: 'bg-gray-100 text-gray-500', icon: <X className="h-3 w-3" /> },
+};
+
+export default function OpportunityDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const opportunityId = params.id as string;
+
+  const [opportunity, setOpportunity] = useState<AgencyOpportunity | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+
+  // Form state for editing
+  const [formData, setFormData] = useState({
+    title: '',
+    brand_name: '',
+    brand_logo_url: '',
+    description: '',
+    deadline: '',
+    content_deadline: '',
+    compensation: {
+      type: 'flat_fee' as const,
+      amount: 0,
+      currency: 'USD',
+      payment_terms: '',
+      product_value: 0,
+      notes: '',
+    },
+    requirements: {
+      deliverables: [''],
+      content_guidelines: '',
+      talking_points: [''],
+      restrictions: [''],
+    },
+  });
+
+  useEffect(() => {
+    const fetchOpportunity = async () => {
+      try {
+        const data = await opportunityApi.get(opportunityId);
+        setOpportunity(data);
+        setFormData({
+          title: data.title,
+          brand_name: data.brand_name,
+          brand_logo_url: data.brand_logo_url || '',
+          description: data.description,
+          deadline: data.deadline ? data.deadline.split('T')[0] : '',
+          content_deadline: data.content_deadline ? data.content_deadline.split('T')[0] : '',
+          compensation: {
+            type: data.compensation.type || 'flat_fee',
+            amount: data.compensation.amount || 0,
+            currency: data.compensation.currency || 'USD',
+            payment_terms: data.compensation.payment_terms || '',
+            product_value: data.compensation.product_value || 0,
+            notes: data.compensation.notes || '',
+          },
+          requirements: {
+            deliverables: data.requirements.deliverables?.length ? data.requirements.deliverables : [''],
+            content_guidelines: data.requirements.content_guidelines || '',
+            talking_points: data.requirements.talking_points?.length ? data.requirements.talking_points : [''],
+            restrictions: data.requirements.restrictions?.length ? data.requirements.restrictions : [''],
+          },
+        });
+      } catch (error) {
+        console.error('Failed to fetch opportunity:', error);
+        toast.error('Failed to load opportunity');
+        router.push('/agency/opportunities');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchOpportunity();
+  }, [opportunityId, router]);
+
+  const handleSave = async () => {
+    if (!opportunity) return;
+
+    setIsSaving(true);
+    try {
+      const updateData = {
+        title: formData.title,
+        brand_name: formData.brand_name,
+        brand_logo_url: formData.brand_logo_url || undefined,
+        description: formData.description,
+        deadline: formData.deadline || undefined,
+        content_deadline: formData.content_deadline || undefined,
+        compensation: {
+          ...formData.compensation,
+          amount: formData.compensation.amount || undefined,
+          product_value: formData.compensation.product_value || undefined,
+        },
+        requirements: {
+          deliverables: formData.requirements.deliverables.filter(d => d.trim()),
+          content_guidelines: formData.requirements.content_guidelines || undefined,
+          talking_points: formData.requirements.talking_points.filter(t => t.trim()),
+          restrictions: formData.requirements.restrictions.filter(r => r.trim()),
+        },
+      };
+
+      const updated = await opportunityApi.update(opportunityId, updateData);
+      setOpportunity(updated);
+      setIsEditing(false);
+      toast.success('Opportunity updated successfully');
+    } catch (error) {
+      console.error('Failed to update opportunity:', error);
+      toast.error('Failed to update opportunity');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleSend = async () => {
+    if (!opportunity) return;
+
+    setIsSaving(true);
+    try {
+      const updated = await opportunityApi.send(opportunityId);
+      setOpportunity(updated);
+      toast.success('Opportunity sent to creator!');
+    } catch (error) {
+      console.error('Failed to send opportunity:', error);
+      toast.error('Failed to send opportunity');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!opportunity) return;
+
+    setIsSaving(true);
+    try {
+      const updated = await opportunityApi.cancel(opportunityId);
+      setOpportunity(updated);
+      toast.success('Opportunity cancelled');
+    } catch (error) {
+      console.error('Failed to cancel opportunity:', error);
+      toast.error('Failed to cancel opportunity');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleComplete = async () => {
+    if (!opportunity) return;
+
+    setIsSaving(true);
+    try {
+      const updated = await opportunityApi.complete(opportunityId);
+      setOpportunity(updated);
+      toast.success('Opportunity marked as completed!');
+    } catch (error) {
+      console.error('Failed to complete opportunity:', error);
+      toast.error('Failed to mark as completed');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!opportunity) return;
+
+    setIsSaving(true);
+    try {
+      await opportunityApi.delete(opportunityId);
+      toast.success('Opportunity deleted');
+      router.push('/agency/opportunities');
+    } catch (error) {
+      console.error('Failed to delete opportunity:', error);
+      toast.error('Failed to delete opportunity');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const addArrayItem = (field: 'deliverables' | 'talking_points' | 'restrictions') => {
+    setFormData(prev => ({
+      ...prev,
+      requirements: {
+        ...prev.requirements,
+        [field]: [...prev.requirements[field], ''],
+      },
+    }));
+  };
+
+  const removeArrayItem = (field: 'deliverables' | 'talking_points' | 'restrictions', index: number) => {
+    setFormData(prev => ({
+      ...prev,
+      requirements: {
+        ...prev.requirements,
+        [field]: prev.requirements[field].filter((_, i) => i !== index),
+      },
+    }));
+  };
+
+  const updateArrayItem = (field: 'deliverables' | 'talking_points' | 'restrictions', index: number, value: string) => {
+    setFormData(prev => ({
+      ...prev,
+      requirements: {
+        ...prev.requirements,
+        [field]: prev.requirements[field].map((item, i) => i === index ? value : item),
+      },
+    }));
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <LoadingSpinner size="large" />
+      </div>
+    );
+  }
+
+  if (!opportunity) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-gray-500">Opportunity not found</p>
+        <Button asChild className="mt-4">
+          <Link href="/agency/opportunities">Back to Opportunities</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  const status = statusConfig[opportunity.status];
+  const canEdit = opportunity.status === 'draft';
+  const canSend = opportunity.status === 'draft';
+  const canCancel = ['sent', 'viewed'].includes(opportunity.status);
+  const canComplete = opportunity.status === 'accepted';
+  const canDelete = opportunity.status === 'draft';
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/agency/opportunities">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back
+            </Link>
+          </Button>
+          <div>
+            <div className="flex items-center gap-3">
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                {opportunity.title}
+              </h1>
+              <Badge className={status.color}>
+                <span className="mr-1">{status.icon}</span>
+                {status.label}
+              </Badge>
+            </div>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              For {opportunity.creator_full_name || opportunity.creator_email || 'Creator'}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex gap-2">
+          {canEdit && !isEditing && (
+            <Button variant="outline" onClick={() => setIsEditing(true)}>
+              Edit
+            </Button>
+          )}
+          {isEditing && (
+            <>
+              <Button variant="outline" onClick={() => setIsEditing(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleSave} disabled={isSaving}>
+                <Save className="h-4 w-4 mr-2" />
+                Save Changes
+              </Button>
+            </>
+          )}
+          {canSend && !isEditing && (
+            <Button onClick={handleSend} disabled={isSaving} className="bg-green-600 hover:bg-green-700">
+              <Send className="h-4 w-4 mr-2" />
+              Send to Creator
+            </Button>
+          )}
+          {canComplete && (
+            <Button onClick={handleComplete} disabled={isSaving} className="bg-emerald-600 hover:bg-emerald-700">
+              <CheckCircle className="h-4 w-4 mr-2" />
+              Mark Completed
+            </Button>
+          )}
+          {canCancel && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="outline" className="text-orange-600 border-orange-300 hover:bg-orange-50">
+                  <X className="h-4 w-4 mr-2" />
+                  Cancel
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Cancel this opportunity?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will notify the creator that the opportunity has been cancelled.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Keep Open</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleCancel} className="bg-orange-600 hover:bg-orange-700">
+                    Cancel Opportunity
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+          {canDelete && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="outline" className="text-red-600 border-red-300 hover:bg-red-50">
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  Delete
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete this opportunity?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This action cannot be undone. The opportunity will be permanently deleted.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleDelete} className="bg-red-600 hover:bg-red-700">
+                    Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+        </div>
+      </div>
+
+      {/* Creator Response Note */}
+      {opportunity.creator_notes && (
+        <Card className="border-blue-200 bg-blue-50 dark:bg-blue-900/10 dark:border-blue-800">
+          <CardContent className="py-4">
+            <div className="flex items-start gap-3">
+              <User className="h-5 w-5 text-blue-600 mt-0.5" />
+              <div>
+                <p className="font-medium text-gray-900 dark:text-gray-100">Creator&apos;s Response Note</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">{opportunity.creator_notes}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Main Content */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* Basic Info */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Building2 className="h-5 w-5" />
+                Campaign Details
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {isEditing ? (
+                <>
+                  <div className="space-y-2">
+                    <Label htmlFor="title">Opportunity Title</Label>
+                    <Input
+                      id="title"
+                      value={formData.title}
+                      onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
+                    />
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor="brand_name">Brand Name</Label>
+                      <Input
+                        id="brand_name"
+                        value={formData.brand_name}
+                        onChange={(e) => setFormData(prev => ({ ...prev, brand_name: e.target.value }))}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="brand_logo_url">Brand Logo URL</Label>
+                      <Input
+                        id="brand_logo_url"
+                        value={formData.brand_logo_url}
+                        onChange={(e) => setFormData(prev => ({ ...prev, brand_logo_url: e.target.value }))}
+                        placeholder="https://..."
+                      />
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="description">Description</Label>
+                    <Textarea
+                      id="description"
+                      value={formData.description}
+                      onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+                      rows={4}
+                    />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="flex items-center gap-3">
+                    <div className="h-12 w-12 rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
+                      {opportunity.brand_logo_url ? (
+                        <img src={opportunity.brand_logo_url} alt={opportunity.brand_name} className="h-10 w-10 rounded object-cover" />
+                      ) : (
+                        <Building2 className="h-6 w-6 text-gray-400" />
+                      )}
+                    </div>
+                    <div>
+                      <p className="font-semibold text-lg">{opportunity.brand_name}</p>
+                      <p className="text-sm text-gray-500">Brand Partner</p>
+                    </div>
+                  </div>
+                  <div className="pt-4 border-t">
+                    <p className="text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{opportunity.description}</p>
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Requirements */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <FileText className="h-5 w-5" />
+                Requirements
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {/* Deliverables */}
+              <div className="space-y-3">
+                <Label>Deliverables</Label>
+                {isEditing ? (
+                  <>
+                    {formData.requirements.deliverables.map((item, index) => (
+                      <div key={index} className="flex gap-2">
+                        <Input
+                          value={item}
+                          onChange={(e) => updateArrayItem('deliverables', index, e.target.value)}
+                          placeholder="e.g., 1 YouTube video (10+ minutes)"
+                        />
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          onClick={() => removeArrayItem('deliverables', index)}
+                          disabled={formData.requirements.deliverables.length === 1}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ))}
+                    <Button type="button" variant="outline" size="sm" onClick={() => addArrayItem('deliverables')}>
+                      <Plus className="h-4 w-4 mr-2" />
+                      Add Deliverable
+                    </Button>
+                  </>
+                ) : (
+                  <ul className="list-disc list-inside space-y-1 text-gray-700 dark:text-gray-300">
+                    {opportunity.requirements.deliverables?.map((item, i) => (
+                      <li key={i}>{item}</li>
+                    )) || <li className="text-gray-400">No deliverables specified</li>}
+                  </ul>
+                )}
+              </div>
+
+              {/* Talking Points */}
+              <div className="space-y-3">
+                <Label>Talking Points</Label>
+                {isEditing ? (
+                  <>
+                    {formData.requirements.talking_points.map((item, index) => (
+                      <div key={index} className="flex gap-2">
+                        <Input
+                          value={item}
+                          onChange={(e) => updateArrayItem('talking_points', index, e.target.value)}
+                          placeholder="Key point to mention"
+                        />
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          onClick={() => removeArrayItem('talking_points', index)}
+                          disabled={formData.requirements.talking_points.length === 1}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ))}
+                    <Button type="button" variant="outline" size="sm" onClick={() => addArrayItem('talking_points')}>
+                      <Plus className="h-4 w-4 mr-2" />
+                      Add Talking Point
+                    </Button>
+                  </>
+                ) : (
+                  <ul className="list-disc list-inside space-y-1 text-gray-700 dark:text-gray-300">
+                    {opportunity.requirements.talking_points?.map((item, i) => (
+                      <li key={i}>{item}</li>
+                    )) || <li className="text-gray-400">No talking points specified</li>}
+                  </ul>
+                )}
+              </div>
+
+              {/* Restrictions */}
+              <div className="space-y-3">
+                <Label>Restrictions</Label>
+                {isEditing ? (
+                  <>
+                    {formData.requirements.restrictions.map((item, index) => (
+                      <div key={index} className="flex gap-2">
+                        <Input
+                          value={item}
+                          onChange={(e) => updateArrayItem('restrictions', index, e.target.value)}
+                          placeholder="e.g., No competitor mentions"
+                        />
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          onClick={() => removeArrayItem('restrictions', index)}
+                          disabled={formData.requirements.restrictions.length === 1}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ))}
+                    <Button type="button" variant="outline" size="sm" onClick={() => addArrayItem('restrictions')}>
+                      <Plus className="h-4 w-4 mr-2" />
+                      Add Restriction
+                    </Button>
+                  </>
+                ) : (
+                  <ul className="list-disc list-inside space-y-1 text-gray-700 dark:text-gray-300">
+                    {opportunity.requirements.restrictions?.map((item, i) => (
+                      <li key={i} className="text-orange-600 dark:text-orange-400">{item}</li>
+                    )) || <li className="text-gray-400">No restrictions specified</li>}
+                  </ul>
+                )}
+              </div>
+
+              {/* Content Guidelines */}
+              <div className="space-y-2">
+                <Label>Content Guidelines</Label>
+                {isEditing ? (
+                  <Textarea
+                    value={formData.requirements.content_guidelines}
+                    onChange={(e) => setFormData(prev => ({
+                      ...prev,
+                      requirements: { ...prev.requirements, content_guidelines: e.target.value }
+                    }))}
+                    placeholder="Additional guidelines for content creation..."
+                    rows={3}
+                  />
+                ) : (
+                  <p className="text-gray-700 dark:text-gray-300">
+                    {opportunity.requirements.content_guidelines || <span className="text-gray-400">No additional guidelines</span>}
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+          {/* Compensation */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <DollarSign className="h-5 w-5" />
+                Compensation
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {isEditing ? (
+                <>
+                  <div className="space-y-2">
+                    <Label>Payment Type</Label>
+                    <Select
+                      value={formData.compensation.type}
+                      onValueChange={(value: 'flat_fee' | 'cpm' | 'hybrid' | 'product_only') =>
+                        setFormData(prev => ({ ...prev, compensation: { ...prev.compensation, type: value } }))
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="flat_fee">Flat Fee</SelectItem>
+                        <SelectItem value="cpm">CPM</SelectItem>
+                        <SelectItem value="hybrid">Hybrid</SelectItem>
+                        <SelectItem value="product_only">Product Only</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  {formData.compensation.type !== 'product_only' && (
+                    <div className="grid gap-4 grid-cols-2">
+                      <div className="space-y-2">
+                        <Label>Amount</Label>
+                        <Input
+                          type="number"
+                          value={formData.compensation.amount || ''}
+                          onChange={(e) => setFormData(prev => ({
+                            ...prev,
+                            compensation: { ...prev.compensation, amount: parseFloat(e.target.value) || 0 }
+                          }))}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label>Currency</Label>
+                        <Select
+                          value={formData.compensation.currency}
+                          onValueChange={(value) => setFormData(prev => ({
+                            ...prev,
+                            compensation: { ...prev.compensation, currency: value }
+                          }))}
+                        >
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="USD">USD</SelectItem>
+                            <SelectItem value="EUR">EUR</SelectItem>
+                            <SelectItem value="GBP">GBP</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
+                  )}
+                  <div className="space-y-2">
+                    <Label>Payment Terms</Label>
+                    <Input
+                      value={formData.compensation.payment_terms}
+                      onChange={(e) => setFormData(prev => ({
+                        ...prev,
+                        compensation: { ...prev.compensation, payment_terms: e.target.value }
+                      }))}
+                      placeholder="e.g., Net 30 after content goes live"
+                    />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="text-center py-4">
+                    <p className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+                      {opportunity.compensation.type === 'product_only' ? (
+                        'Product Only'
+                      ) : (
+                        `${opportunity.compensation.currency || 'USD'} ${opportunity.compensation.amount?.toLocaleString() || 0}`
+                      )}
+                    </p>
+                    <p className="text-sm text-gray-500 capitalize mt-1">
+                      {opportunity.compensation.type?.replace('_', ' ')}
+                    </p>
+                  </div>
+                  {opportunity.compensation.payment_terms && (
+                    <div className="border-t pt-4">
+                      <p className="text-sm text-gray-500">Payment Terms</p>
+                      <p className="text-gray-700 dark:text-gray-300">{opportunity.compensation.payment_terms}</p>
+                    </div>
+                  )}
+                  {opportunity.compensation.notes && (
+                    <div className="border-t pt-4">
+                      <p className="text-sm text-gray-500">Notes</p>
+                      <p className="text-gray-700 dark:text-gray-300">{opportunity.compensation.notes}</p>
+                    </div>
+                  )}
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Deadlines */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Clock className="h-5 w-5" />
+                Deadlines
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {isEditing ? (
+                <>
+                  <div className="space-y-2">
+                    <Label>Response Deadline</Label>
+                    <Input
+                      type="date"
+                      value={formData.deadline}
+                      onChange={(e) => setFormData(prev => ({ ...prev, deadline: e.target.value }))}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Content Deadline</Label>
+                    <Input
+                      type="date"
+                      value={formData.content_deadline}
+                      onChange={(e) => setFormData(prev => ({ ...prev, content_deadline: e.target.value }))}
+                    />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div>
+                    <p className="text-sm text-gray-500">Response By</p>
+                    <p className="text-gray-700 dark:text-gray-300">
+                      {opportunity.deadline ? new Date(opportunity.deadline).toLocaleDateString() : 'No deadline set'}
+                    </p>
+                  </div>
+                  <div className="border-t pt-4">
+                    <p className="text-sm text-gray-500">Content Due</p>
+                    <p className="text-gray-700 dark:text-gray-300">
+                      {opportunity.content_deadline ? new Date(opportunity.content_deadline).toLocaleDateString() : 'No deadline set'}
+                    </p>
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Activity */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Activity</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div className="flex justify-between">
+                <span className="text-gray-500">Created</span>
+                <span className="text-gray-700 dark:text-gray-300">
+                  {new Date(opportunity.created_at).toLocaleDateString()}
+                </span>
+              </div>
+              {opportunity.sent_at && (
+                <div className="flex justify-between">
+                  <span className="text-gray-500">Sent</span>
+                  <span className="text-gray-700 dark:text-gray-300">
+                    {new Date(opportunity.sent_at).toLocaleDateString()}
+                  </span>
+                </div>
+              )}
+              {opportunity.viewed_at && (
+                <div className="flex justify-between">
+                  <span className="text-gray-500">Viewed</span>
+                  <span className="text-gray-700 dark:text-gray-300">
+                    {new Date(opportunity.viewed_at).toLocaleDateString()}
+                  </span>
+                </div>
+              )}
+              {opportunity.creator_response_at && (
+                <div className="flex justify-between">
+                  <span className="text-gray-500">
+                    {opportunity.status === 'accepted' ? 'Accepted' : opportunity.status === 'declined' ? 'Declined' : 'Responded'}
+                  </span>
+                  <span className="text-gray-700 dark:text-gray-300">
+                    {new Date(opportunity.creator_response_at).toLocaleDateString()}
+                  </span>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(agency)/agency/opportunities/new/page.tsx
+++ b/frontend/app/(agency)/agency/opportunities/new/page.tsx
@@ -1,0 +1,608 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  ArrowLeft,
+  Briefcase,
+  DollarSign,
+  User,
+  Calendar,
+  Plus,
+  X,
+  Send,
+  Save,
+  Loader2,
+  AlertCircle,
+} from 'lucide-react';
+import { agencyApi, opportunityApi, type AgencyCreator, type CreateOpportunityData } from '@/lib/agency-api';
+import { toast } from 'sonner';
+
+type CompensationType = 'flat_fee' | 'cpm' | 'hybrid' | 'product_only';
+
+export default function NewOpportunityPage() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetchingCreators, setIsFetchingCreators] = useState(true);
+  const [creators, setCreators] = useState<AgencyCreator[]>([]);
+
+  // Form state
+  const [formData, setFormData] = useState({
+    creator_id: '',
+    title: '',
+    brand_name: '',
+    brand_logo_url: '',
+    description: '',
+    deadline: '',
+    content_deadline: '',
+    // Compensation
+    compensation_type: 'flat_fee' as CompensationType,
+    compensation_amount: '',
+    compensation_currency: 'USD',
+    compensation_payment_terms: '',
+    compensation_product_value: '',
+    compensation_notes: '',
+    // Requirements
+    deliverables: [''],
+    talking_points: [''],
+    restrictions: [''],
+    content_guidelines: '',
+  });
+
+  useEffect(() => {
+    fetchCreators();
+  }, []);
+
+  const fetchCreators = async () => {
+    try {
+      const data = await agencyApi.getCreators();
+      setCreators(data);
+    } catch (error) {
+      console.error('Failed to fetch creators:', error);
+      toast.error('Failed to load creators');
+    } finally {
+      setIsFetchingCreators(false);
+    }
+  };
+
+  const handleArrayItemChange = (field: 'deliverables' | 'talking_points' | 'restrictions', index: number, value: string) => {
+    setFormData((prev) => {
+      const newArray = [...prev[field]];
+      newArray[index] = value;
+      return { ...prev, [field]: newArray };
+    });
+  };
+
+  const addArrayItem = (field: 'deliverables' | 'talking_points' | 'restrictions') => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: [...prev[field], ''],
+    }));
+  };
+
+  const removeArrayItem = (field: 'deliverables' | 'talking_points' | 'restrictions', index: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: prev[field].filter((_, i) => i !== index),
+    }));
+  };
+
+  const buildOpportunityData = (): CreateOpportunityData => {
+    const compensation: CreateOpportunityData['compensation'] = {
+      type: formData.compensation_type,
+      currency: formData.compensation_currency,
+    };
+
+    if (formData.compensation_amount) {
+      compensation.amount = parseFloat(formData.compensation_amount);
+    }
+    if (formData.compensation_payment_terms) {
+      compensation.payment_terms = formData.compensation_payment_terms;
+    }
+    if (formData.compensation_product_value) {
+      compensation.product_value = parseFloat(formData.compensation_product_value);
+    }
+    if (formData.compensation_notes) {
+      compensation.notes = formData.compensation_notes;
+    }
+
+    const requirements: CreateOpportunityData['requirements'] = {};
+    const filteredDeliverables = formData.deliverables.filter((d) => d.trim());
+    const filteredTalkingPoints = formData.talking_points.filter((t) => t.trim());
+    const filteredRestrictions = formData.restrictions.filter((r) => r.trim());
+
+    if (filteredDeliverables.length) requirements.deliverables = filteredDeliverables;
+    if (filteredTalkingPoints.length) requirements.talking_points = filteredTalkingPoints;
+    if (filteredRestrictions.length) requirements.restrictions = filteredRestrictions;
+    if (formData.content_guidelines) requirements.content_guidelines = formData.content_guidelines;
+
+    return {
+      creator_id: formData.creator_id,
+      title: formData.title,
+      brand_name: formData.brand_name,
+      brand_logo_url: formData.brand_logo_url || undefined,
+      description: formData.description,
+      deadline: formData.deadline || undefined,
+      content_deadline: formData.content_deadline || undefined,
+      compensation,
+      requirements,
+    };
+  };
+
+  const handleSaveAsDraft = async () => {
+    if (!formData.creator_id || !formData.title || !formData.brand_name || !formData.description) {
+      toast.error('Please fill in all required fields');
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const data = buildOpportunityData();
+      await opportunityApi.create(data);
+      toast.success('Opportunity saved as draft');
+      router.push('/agency/opportunities');
+    } catch (error: unknown) {
+      const err = error as { response?: { data?: { detail?: string } } };
+      toast.error(err.response?.data?.detail || 'Failed to save opportunity');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCreateAndSend = async () => {
+    if (!formData.creator_id || !formData.title || !formData.brand_name || !formData.description) {
+      toast.error('Please fill in all required fields');
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const data = buildOpportunityData();
+      const opportunity = await opportunityApi.create(data);
+      await opportunityApi.send(opportunity.id);
+      toast.success('Opportunity created and sent to creator!');
+      router.push('/agency/opportunities');
+    } catch (error: unknown) {
+      const err = error as { response?: { data?: { detail?: string } } };
+      toast.error(err.response?.data?.detail || 'Failed to create opportunity');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isFetchingCreators) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  if (creators.length === 0) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <Link
+            href="/agency/opportunities"
+            className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700 mb-4"
+          >
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            Back to Opportunities
+          </Link>
+        </div>
+        <Card className="border-dashed">
+          <CardContent className="py-12">
+            <div className="text-center">
+              <div className="mx-auto h-16 w-16 rounded-full bg-orange-50 dark:bg-orange-900/20 flex items-center justify-center mb-4">
+                <AlertCircle className="h-8 w-8 text-orange-600 dark:text-orange-400" />
+              </div>
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                No creators in your agency
+              </h3>
+              <p className="text-gray-600 dark:text-gray-400 max-w-md mx-auto mb-6">
+                You need to invite creators to your agency before you can send them opportunities.
+              </p>
+              <Button asChild className="bg-green-600 hover:bg-green-700">
+                <Link href="/agency/creators">
+                  <User className="mr-2 h-4 w-4" />
+                  Invite Creators
+                </Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 max-w-4xl">
+      {/* Header */}
+      <div>
+        <Link
+          href="/agency/opportunities"
+          className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700 mb-4"
+        >
+          <ArrowLeft className="mr-1 h-4 w-4" />
+          Back to Opportunities
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          New Sponsorship Opportunity
+        </h1>
+        <p className="mt-1 text-gray-600 dark:text-gray-400">
+          Create a new sponsorship opportunity for one of your creators
+        </p>
+      </div>
+
+      {/* Form */}
+      <div className="space-y-6">
+        {/* Basic Info */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Briefcase className="h-5 w-5" />
+              Basic Information
+            </CardTitle>
+            <CardDescription>
+              Enter the main details about this sponsorship opportunity
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="creator">Creator *</Label>
+              <Select
+                value={formData.creator_id}
+                onValueChange={(v) => setFormData((prev) => ({ ...prev, creator_id: v }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a creator" />
+                </SelectTrigger>
+                <SelectContent>
+                  {creators.map((creator) => (
+                    <SelectItem key={creator.id} value={creator.id}>
+                      <div className="flex items-center gap-2">
+                        <User className="h-4 w-4" />
+                        {creator.full_name || creator.email}
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="title">Opportunity Title *</Label>
+              <Input
+                id="title"
+                placeholder="e.g., Summer Product Launch Campaign"
+                value={formData.title}
+                onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
+              />
+            </div>
+
+            <div className="grid sm:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="brand_name">Brand Name *</Label>
+                <Input
+                  id="brand_name"
+                  placeholder="e.g., Acme Corp"
+                  value={formData.brand_name}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, brand_name: e.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="brand_logo_url">Brand Logo URL</Label>
+                <Input
+                  id="brand_logo_url"
+                  type="url"
+                  placeholder="https://..."
+                  value={formData.brand_logo_url}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, brand_logo_url: e.target.value }))}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Description *</Label>
+              <Textarea
+                id="description"
+                placeholder="Describe the sponsorship opportunity, what the brand is looking for, and any important context..."
+                rows={4}
+                value={formData.description}
+                onChange={(e) => setFormData((prev) => ({ ...prev, description: e.target.value }))}
+              />
+            </div>
+
+            <div className="grid sm:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="deadline">Response Deadline</Label>
+                <Input
+                  id="deadline"
+                  type="datetime-local"
+                  value={formData.deadline}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, deadline: e.target.value }))}
+                />
+                <p className="text-xs text-gray-500">When the creator needs to respond by</p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="content_deadline">Content Deadline</Label>
+                <Input
+                  id="content_deadline"
+                  type="datetime-local"
+                  value={formData.content_deadline}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, content_deadline: e.target.value }))}
+                />
+                <p className="text-xs text-gray-500">When the content needs to be delivered</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Compensation */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <DollarSign className="h-5 w-5" />
+              Compensation
+            </CardTitle>
+            <CardDescription>
+              Define the payment terms for this sponsorship
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid sm:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="compensation_type">Compensation Type</Label>
+                <Select
+                  value={formData.compensation_type}
+                  onValueChange={(v) => setFormData((prev) => ({ ...prev, compensation_type: v as CompensationType }))}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="flat_fee">Flat Fee</SelectItem>
+                    <SelectItem value="cpm">CPM (Per 1000 views)</SelectItem>
+                    <SelectItem value="hybrid">Hybrid (Fee + CPM)</SelectItem>
+                    <SelectItem value="product_only">Product Only</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="compensation_currency">Currency</Label>
+                <Select
+                  value={formData.compensation_currency}
+                  onValueChange={(v) => setFormData((prev) => ({ ...prev, compensation_currency: v }))}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="USD">USD ($)</SelectItem>
+                    <SelectItem value="EUR">EUR (€)</SelectItem>
+                    <SelectItem value="GBP">GBP (£)</SelectItem>
+                    <SelectItem value="CAD">CAD ($)</SelectItem>
+                    <SelectItem value="AUD">AUD ($)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="grid sm:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="compensation_amount">Payment Amount</Label>
+                <Input
+                  id="compensation_amount"
+                  type="number"
+                  placeholder="e.g., 5000"
+                  value={formData.compensation_amount}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, compensation_amount: e.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="compensation_product_value">Product Value</Label>
+                <Input
+                  id="compensation_product_value"
+                  type="number"
+                  placeholder="e.g., 500"
+                  value={formData.compensation_product_value}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, compensation_product_value: e.target.value }))}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="compensation_payment_terms">Payment Terms</Label>
+              <Input
+                id="compensation_payment_terms"
+                placeholder="e.g., 50% upfront, 50% on completion"
+                value={formData.compensation_payment_terms}
+                onChange={(e) => setFormData((prev) => ({ ...prev, compensation_payment_terms: e.target.value }))}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="compensation_notes">Additional Notes</Label>
+              <Textarea
+                id="compensation_notes"
+                placeholder="Any additional compensation details..."
+                rows={2}
+                value={formData.compensation_notes}
+                onChange={(e) => setFormData((prev) => ({ ...prev, compensation_notes: e.target.value }))}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Requirements */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Calendar className="h-5 w-5" />
+              Requirements
+            </CardTitle>
+            <CardDescription>
+              Specify what the creator needs to deliver
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {/* Deliverables */}
+            <div className="space-y-2">
+              <Label>Deliverables</Label>
+              <p className="text-xs text-gray-500 mb-2">What content does the creator need to produce?</p>
+              {formData.deliverables.map((item, index) => (
+                <div key={index} className="flex gap-2">
+                  <Input
+                    placeholder="e.g., 1 YouTube video (10+ mins)"
+                    value={item}
+                    onChange={(e) => handleArrayItemChange('deliverables', index, e.target.value)}
+                  />
+                  {formData.deliverables.length > 1 && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => removeArrayItem('deliverables', index)}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+              ))}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => addArrayItem('deliverables')}
+              >
+                <Plus className="mr-1 h-4 w-4" />
+                Add Deliverable
+              </Button>
+            </div>
+
+            {/* Talking Points */}
+            <div className="space-y-2">
+              <Label>Key Talking Points</Label>
+              <p className="text-xs text-gray-500 mb-2">What should the creator mention?</p>
+              {formData.talking_points.map((item, index) => (
+                <div key={index} className="flex gap-2">
+                  <Input
+                    placeholder="e.g., Highlight the product's ease of use"
+                    value={item}
+                    onChange={(e) => handleArrayItemChange('talking_points', index, e.target.value)}
+                  />
+                  {formData.talking_points.length > 1 && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => removeArrayItem('talking_points', index)}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+              ))}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => addArrayItem('talking_points')}
+              >
+                <Plus className="mr-1 h-4 w-4" />
+                Add Talking Point
+              </Button>
+            </div>
+
+            {/* Restrictions */}
+            <div className="space-y-2">
+              <Label>Restrictions</Label>
+              <p className="text-xs text-gray-500 mb-2">What should the creator avoid?</p>
+              {formData.restrictions.map((item, index) => (
+                <div key={index} className="flex gap-2">
+                  <Input
+                    placeholder="e.g., No competitor mentions"
+                    value={item}
+                    onChange={(e) => handleArrayItemChange('restrictions', index, e.target.value)}
+                  />
+                  {formData.restrictions.length > 1 && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => removeArrayItem('restrictions', index)}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+              ))}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => addArrayItem('restrictions')}
+              >
+                <Plus className="mr-1 h-4 w-4" />
+                Add Restriction
+              </Button>
+            </div>
+
+            {/* Content Guidelines */}
+            <div className="space-y-2">
+              <Label htmlFor="content_guidelines">Content Guidelines</Label>
+              <Textarea
+                id="content_guidelines"
+                placeholder="Any additional guidelines for the content..."
+                rows={3}
+                value={formData.content_guidelines}
+                onChange={(e) => setFormData((prev) => ({ ...prev, content_guidelines: e.target.value }))}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Actions */}
+        <div className="flex flex-col sm:flex-row gap-3 justify-end">
+          <Button
+            variant="outline"
+            onClick={handleSaveAsDraft}
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="mr-2 h-4 w-4" />
+            )}
+            Save as Draft
+          </Button>
+          <Button
+            className="bg-green-600 hover:bg-green-700"
+            onClick={handleCreateAndSend}
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="mr-2 h-4 w-4" />
+            )}
+            Create & Send to Creator
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(agency)/agency/opportunities/page.tsx
+++ b/frontend/app/(agency)/agency/opportunities/page.tsx
@@ -1,0 +1,333 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Briefcase,
+  Plus,
+  Search,
+  Calendar,
+  DollarSign,
+  User,
+  MoreVertical,
+  Clock,
+  CheckCircle,
+  XCircle,
+  Eye,
+  Send,
+  Loader2,
+  Trash2,
+  Ban,
+} from 'lucide-react';
+import { opportunityApi, type AgencyOpportunityListItem, type OpportunityStatus } from '@/lib/agency-api';
+import { toast } from 'sonner';
+
+const statusConfig: Record<OpportunityStatus, { label: string; color: string; icon: React.ElementType }> = {
+  draft: { label: 'Draft', color: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300', icon: Clock },
+  sent: { label: 'Sent', color: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300', icon: Send },
+  viewed: { label: 'Viewed', color: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300', icon: Eye },
+  accepted: { label: 'Accepted', color: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300', icon: CheckCircle },
+  declined: { label: 'Declined', color: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300', icon: XCircle },
+  completed: { label: 'Completed', color: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300', icon: CheckCircle },
+  cancelled: { label: 'Cancelled', color: 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400', icon: XCircle },
+};
+
+export default function AgencyOpportunitiesPage() {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [isLoading, setIsLoading] = useState(true);
+  const [opportunities, setOpportunities] = useState<AgencyOpportunityListItem[]>([]);
+
+  useEffect(() => {
+    fetchOpportunities();
+  }, [statusFilter]);
+
+  const fetchOpportunities = async () => {
+    setIsLoading(true);
+    try {
+      const params: { status?: OpportunityStatus } = {};
+      if (statusFilter && statusFilter !== 'all') {
+        params.status = statusFilter as OpportunityStatus;
+      }
+      const data = await opportunityApi.list(params);
+      setOpportunities(data);
+    } catch (error) {
+      console.error('Failed to fetch opportunities:', error);
+      toast.error('Failed to load opportunities');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSend = async (id: string) => {
+    try {
+      await opportunityApi.send(id);
+      toast.success('Opportunity sent to creator!');
+      fetchOpportunities();
+    } catch (error) {
+      toast.error('Failed to send opportunity');
+    }
+  };
+
+  const handleCancel = async (id: string) => {
+    if (!confirm('Are you sure you want to cancel this opportunity?')) return;
+    try {
+      await opportunityApi.cancel(id);
+      toast.success('Opportunity cancelled');
+      fetchOpportunities();
+    } catch (error) {
+      toast.error('Failed to cancel opportunity');
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Are you sure you want to delete this draft?')) return;
+    try {
+      await opportunityApi.delete(id);
+      toast.success('Draft deleted');
+      fetchOpportunities();
+    } catch (error) {
+      toast.error('Failed to delete draft');
+    }
+  };
+
+  const handleComplete = async (id: string) => {
+    try {
+      await opportunityApi.complete(id);
+      toast.success('Opportunity marked as completed!');
+      fetchOpportunities();
+    } catch (error) {
+      toast.error('Failed to complete opportunity');
+    }
+  };
+
+  const filteredOpportunities = opportunities.filter(
+    (opp) =>
+      opp.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      opp.brand_name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      opp.creator_full_name?.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Sponsorship Opportunities
+          </h1>
+          <p className="mt-1 text-gray-600 dark:text-gray-400">
+            Create and manage sponsorship deals for your creators
+          </p>
+        </div>
+        <Button asChild className="bg-green-600 hover:bg-green-700">
+          <Link href="/agency/opportunities/new">
+            <Plus className="mr-2 h-4 w-4" />
+            New Opportunity
+          </Link>
+        </Button>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-col sm:flex-row gap-4">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Input
+            placeholder="Search opportunities..."
+            className="pl-10"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+        </div>
+        <Select value={statusFilter} onValueChange={setStatusFilter}>
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Filter by status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Status</SelectItem>
+            <SelectItem value="draft">Draft</SelectItem>
+            <SelectItem value="sent">Sent</SelectItem>
+            <SelectItem value="viewed">Viewed</SelectItem>
+            <SelectItem value="accepted">Accepted</SelectItem>
+            <SelectItem value="declined">Declined</SelectItem>
+            <SelectItem value="completed">Completed</SelectItem>
+            <SelectItem value="cancelled">Cancelled</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Opportunities List */}
+      {filteredOpportunities.length === 0 ? (
+        <Card className="border-dashed">
+          <CardContent className="py-12">
+            <div className="text-center">
+              <div className="mx-auto h-16 w-16 rounded-full bg-purple-50 dark:bg-purple-900/20 flex items-center justify-center mb-4">
+                <Briefcase className="h-8 w-8 text-purple-600 dark:text-purple-400" />
+              </div>
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                {searchQuery || statusFilter !== 'all' ? 'No opportunities found' : 'No opportunities yet'}
+              </h3>
+              <p className="text-gray-600 dark:text-gray-400 max-w-md mx-auto mb-6">
+                {searchQuery || statusFilter !== 'all'
+                  ? 'Try adjusting your search or filter criteria'
+                  : "Create your first sponsorship opportunity to send to your creators. They'll be able to accept and start planning the sponsored content."}
+              </p>
+              {!searchQuery && statusFilter === 'all' && (
+                <Button asChild className="bg-green-600 hover:bg-green-700">
+                  <Link href="/agency/opportunities/new">
+                    <Plus className="mr-2 h-4 w-4" />
+                    Create First Opportunity
+                  </Link>
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {filteredOpportunities.map((opportunity) => {
+            const status = statusConfig[opportunity.status];
+            const StatusIcon = status.icon;
+
+            return (
+              <Card key={opportunity.id} className="hover:shadow-md transition-shadow">
+                <CardContent className="py-4">
+                  <div className="flex items-center justify-between">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-3 mb-2">
+                        <h3 className="font-semibold text-gray-900 dark:text-gray-100">
+                          {opportunity.title}
+                        </h3>
+                        <Badge className={status.color}>
+                          <StatusIcon className="mr-1 h-3 w-3" />
+                          {status.label}
+                        </Badge>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
+                        <span className="flex items-center gap-1">
+                          <Briefcase className="h-4 w-4" />
+                          {opportunity.brand_name}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <User className="h-4 w-4" />
+                          {opportunity.creator_full_name || 'Unknown Creator'}
+                        </span>
+                        {opportunity.deadline && (
+                          <span className="flex items-center gap-1">
+                            <Calendar className="h-4 w-4" />
+                            Due {new Date(opportunity.deadline).toLocaleDateString()}
+                          </span>
+                        )}
+                        <span className="text-xs">
+                          Created {new Date(opportunity.created_at).toLocaleDateString()}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {opportunity.status === 'draft' && (
+                        <Button
+                          size="sm"
+                          className="bg-blue-600 hover:bg-blue-700"
+                          onClick={() => handleSend(opportunity.id)}
+                        >
+                          <Send className="mr-1 h-4 w-4" />
+                          Send
+                        </Button>
+                      )}
+                      {opportunity.status === 'accepted' && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="border-green-600 text-green-600 hover:bg-green-50"
+                          onClick={() => handleComplete(opportunity.id)}
+                        >
+                          <CheckCircle className="mr-1 h-4 w-4" />
+                          Mark Complete
+                        </Button>
+                      )}
+                      <Button variant="outline" size="sm" asChild>
+                        <Link href={`/agency/opportunities/${opportunity.id}`}>
+                          View
+                        </Link>
+                      </Button>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon">
+                            <MoreVertical className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem asChild>
+                            <Link href={`/agency/opportunities/${opportunity.id}`}>
+                              <Eye className="mr-2 h-4 w-4" />
+                              View Details
+                            </Link>
+                          </DropdownMenuItem>
+                          {opportunity.status === 'draft' && (
+                            <>
+                              <DropdownMenuItem asChild>
+                                <Link href={`/agency/opportunities/${opportunity.id}/edit`}>
+                                  Edit
+                                </Link>
+                              </DropdownMenuItem>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem
+                                className="text-red-600"
+                                onClick={() => handleDelete(opportunity.id)}
+                              >
+                                <Trash2 className="mr-2 h-4 w-4" />
+                                Delete Draft
+                              </DropdownMenuItem>
+                            </>
+                          )}
+                          {['sent', 'viewed', 'accepted'].includes(opportunity.status) && (
+                            <>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem
+                                className="text-red-600"
+                                onClick={() => handleCancel(opportunity.id)}
+                              >
+                                <Ban className="mr-2 h-4 w-4" />
+                                Cancel Opportunity
+                              </DropdownMenuItem>
+                            </>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/(agency)/agency/page.tsx
+++ b/frontend/app/(agency)/agency/page.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/lib/auth';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { LoadingSpinner } from '@/components/shared/LoadingSpinner';
+import {
+  Users,
+  Briefcase,
+  TrendingUp,
+  UserPlus,
+  ArrowRight,
+  Building2,
+  Plus,
+  Clock,
+} from 'lucide-react';
+import Link from 'next/link';
+import { agencyApi, type AgencyStats } from '@/lib/agency-api';
+import { toast } from 'sonner';
+
+export default function AgencyDashboardPage() {
+  const { user } = useAuth();
+  const [stats, setStats] = useState<AgencyStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      setIsLoading(true);
+      try {
+        const data = await agencyApi.getStats();
+        setStats(data);
+      } catch (error) {
+        console.error('Failed to fetch agency stats:', error);
+        toast.error('Failed to load dashboard data');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchStats();
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <LoadingSpinner size="large" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Welcome Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            Welcome back{user?.full_name ? `, ${user.full_name.split(' ')[0]}` : ''}
+          </h1>
+          <p className="mt-1 text-gray-600 dark:text-gray-400">
+            Manage your creators and sponsorship opportunities
+          </p>
+        </div>
+        <div className="flex gap-3">
+          <Button asChild variant="outline">
+            <Link href="/agency/creators">
+              <UserPlus className="mr-2 h-4 w-4" />
+              Invite Creator
+            </Link>
+          </Button>
+          <Button asChild className="bg-green-600 hover:bg-green-700">
+            <Link href="/agency/opportunities/new">
+              <Plus className="mr-2 h-4 w-4" />
+              New Opportunity
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      {/* Stats Grid */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+              Total Creators
+            </CardTitle>
+            <Users className="h-4 w-4 text-green-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats?.creator_count || 0}</div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Creators in your agency
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+              Total Reach
+            </CardTitle>
+            <TrendingUp className="h-4 w-4 text-blue-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {stats?.total_reach?.toLocaleString() || 0}
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Combined followers
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+              Active Opportunities
+            </CardTitle>
+            <Briefcase className="h-4 w-4 text-purple-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats?.active_opportunities || 0}</div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Open sponsorships
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400">
+              Pending Actions
+            </CardTitle>
+            <Clock className="h-4 w-4 text-orange-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {(stats?.pending_invitations || 0) + (stats?.pending_join_requests || 0)}
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {stats?.pending_invitations || 0} invites, {stats?.pending_join_requests || 0} requests
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Pending Join Requests Alert */}
+      {(stats?.pending_join_requests || 0) > 0 && (
+        <Card className="border-orange-200 bg-orange-50 dark:bg-orange-900/10 dark:border-orange-800">
+          <CardContent className="py-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <div className="h-10 w-10 rounded-full bg-orange-100 dark:bg-orange-900/30 flex items-center justify-center">
+                  <UserPlus className="h-5 w-5 text-orange-600" />
+                </div>
+                <div>
+                  <p className="font-medium text-gray-900 dark:text-gray-100">
+                    {stats?.pending_join_requests} creator{(stats?.pending_join_requests || 0) > 1 ? 's' : ''} waiting to join
+                  </p>
+                  <p className="text-sm text-gray-600 dark:text-gray-400">
+                    Review and approve their requests
+                  </p>
+                </div>
+              </div>
+              <Button asChild variant="outline" className="border-orange-300 hover:bg-orange-100">
+                <Link href="/agency/creators?tab=requests">
+                  Review Requests
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Empty State / Getting Started */}
+      {stats?.creator_count === 0 && (
+        <Card className="border-dashed">
+          <CardContent className="py-12">
+            <div className="text-center">
+              <div className="mx-auto h-16 w-16 rounded-full bg-green-50 dark:bg-green-900/20 flex items-center justify-center mb-4">
+                <Building2 className="h-8 w-8 text-green-600 dark:text-green-400" />
+              </div>
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                Get started with your agency
+              </h3>
+              <p className="text-gray-600 dark:text-gray-400 max-w-md mx-auto mb-6">
+                Invite your first creator to start managing their sponsorship opportunities
+                and track their performance all in one place.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                <Button asChild variant="outline">
+                  <Link href="/agency/team">
+                    <Users className="mr-2 h-4 w-4" />
+                    Add Team Members
+                  </Link>
+                </Button>
+                <Button asChild className="bg-green-600 hover:bg-green-700">
+                  <Link href="/agency/creators">
+                    <UserPlus className="mr-2 h-4 w-4" />
+                    Invite Creators
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Quick Actions */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <Card className="hover:shadow-md transition-shadow cursor-pointer group">
+          <Link href="/agency/creators">
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div className="h-10 w-10 rounded-lg bg-green-50 dark:bg-green-900/20 flex items-center justify-center">
+                  <Users className="h-5 w-5 text-green-600" />
+                </div>
+                <ArrowRight className="h-5 w-5 text-gray-400 group-hover:text-green-600 transition-colors" />
+              </div>
+              <CardTitle className="mt-4">Manage Creators</CardTitle>
+              <CardDescription>
+                View and manage all creators in your agency
+              </CardDescription>
+            </CardHeader>
+          </Link>
+        </Card>
+
+        <Card className="hover:shadow-md transition-shadow cursor-pointer group">
+          <Link href="/agency/opportunities">
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div className="h-10 w-10 rounded-lg bg-purple-50 dark:bg-purple-900/20 flex items-center justify-center">
+                  <Briefcase className="h-5 w-5 text-purple-600" />
+                </div>
+                <ArrowRight className="h-5 w-5 text-gray-400 group-hover:text-purple-600 transition-colors" />
+              </div>
+              <CardTitle className="mt-4">Sponsorship Opportunities</CardTitle>
+              <CardDescription>
+                Create and send sponsorship deals to creators
+              </CardDescription>
+            </CardHeader>
+          </Link>
+        </Card>
+
+        <Card className="hover:shadow-md transition-shadow cursor-pointer group">
+          <Link href="/agency/team">
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div className="h-10 w-10 rounded-lg bg-blue-50 dark:bg-blue-900/20 flex items-center justify-center">
+                  <UserPlus className="h-5 w-5 text-blue-600" />
+                </div>
+                <ArrowRight className="h-5 w-5 text-gray-400 group-hover:text-blue-600 transition-colors" />
+              </div>
+              <CardTitle className="mt-4">Team Management</CardTitle>
+              <CardDescription>
+                Add team members to help manage your agency
+              </CardDescription>
+            </CardHeader>
+          </Link>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(agency)/agency/settings/page.tsx
+++ b/frontend/app/(agency)/agency/settings/page.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/lib/auth';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import {
+  Building2,
+  Globe,
+  Save,
+  Upload,
+  Loader2,
+} from 'lucide-react';
+import { agencyApi, type Agency } from '@/lib/agency-api';
+import { toast } from 'sonner';
+
+export default function AgencySettingsPage() {
+  const { user } = useAuth();
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [agency, setAgency] = useState<Agency | null>(null);
+  const [formData, setFormData] = useState({
+    name: '',
+    website: '',
+    description: '',
+  });
+
+  useEffect(() => {
+    fetchAgency();
+  }, []);
+
+  const fetchAgency = async () => {
+    setIsLoading(true);
+    try {
+      const data = await agencyApi.getMyAgency();
+      setAgency(data);
+      setFormData({
+        name: data.name || '',
+        website: data.website || '',
+        description: data.description || '',
+      });
+    } catch (error) {
+      console.error('Failed to fetch agency:', error);
+      toast.error('Failed to load agency settings');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const updated = await agencyApi.updateAgency({
+        name: formData.name,
+        website: formData.website || undefined,
+        description: formData.description || undefined,
+      });
+      setAgency(updated);
+      toast.success('Settings saved!');
+    } catch (error: unknown) {
+      const err = error as { response?: { data?: { detail?: string } } };
+      toast.error(err.response?.data?.detail || 'Failed to save settings');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          Agency Settings
+        </h1>
+        <p className="mt-1 text-gray-600 dark:text-gray-400">
+          Manage your agency profile and preferences
+        </p>
+      </div>
+
+      {/* Agency Profile */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Agency Profile</CardTitle>
+          <CardDescription>
+            This information will be visible to creators when they receive invitations
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Logo Upload */}
+          <div className="space-y-2">
+            <Label>Agency Logo</Label>
+            <div className="flex items-center gap-4">
+              <div className="h-20 w-20 rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center border-2 border-dashed border-gray-300 dark:border-gray-700 overflow-hidden">
+                {agency?.logo_url ? (
+                  <img
+                    src={agency.logo_url}
+                    alt={agency.name}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <Building2 className="h-8 w-8 text-gray-400" />
+                )}
+              </div>
+              <div>
+                <Button variant="outline" size="sm" disabled>
+                  <Upload className="mr-2 h-4 w-4" />
+                  Upload Logo
+                </Button>
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  PNG, JPG up to 2MB. Recommended 200x200px.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Agency Name */}
+          <div className="space-y-2">
+            <Label htmlFor="name">Agency Name</Label>
+            <Input
+              id="name"
+              placeholder="Your Agency Name"
+              value={formData.name}
+              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+            />
+          </div>
+
+          {/* Website */}
+          <div className="space-y-2">
+            <Label htmlFor="website">Website</Label>
+            <div className="relative">
+              <Globe className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Input
+                id="website"
+                placeholder="https://youragency.com"
+                className="pl-10"
+                value={formData.website}
+                onChange={(e) => setFormData({ ...formData, website: e.target.value })}
+              />
+            </div>
+          </div>
+
+          {/* Description */}
+          <div className="space-y-2">
+            <Label htmlFor="description">Description</Label>
+            <Textarea
+              id="description"
+              placeholder="Tell creators about your agency..."
+              rows={4}
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+            />
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              This description will be shown to creators when they receive invitations.
+            </p>
+          </div>
+
+          <Button
+            onClick={handleSave}
+            disabled={isSaving || !formData.name}
+            className="bg-green-600 hover:bg-green-700"
+          >
+            {isSaving ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              <>
+                <Save className="mr-2 h-4 w-4" />
+                Save Changes
+              </>
+            )}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Account Owner */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Account Owner</CardTitle>
+          <CardDescription>
+            The primary contact for this agency account
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-4">
+            <div className="h-12 w-12 rounded-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center text-white font-medium text-lg">
+              {user?.full_name?.charAt(0) || user?.email?.charAt(0) || 'A'}
+            </div>
+            <div>
+              <p className="font-medium text-gray-900 dark:text-gray-100">
+                {user?.full_name || 'Agency Owner'}
+              </p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {user?.email}
+              </p>
+            </div>
+          </div>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            To transfer ownership, please contact support.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Agency Info */}
+      {agency && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Agency Information</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-gray-500">Agency ID</span>
+              <span className="font-mono text-gray-900 dark:text-gray-100">{agency.id}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">Slug</span>
+              <span className="font-mono text-gray-900 dark:text-gray-100">{agency.slug}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">Created</span>
+              <span className="text-gray-900 dark:text-gray-100">
+                {new Date(agency.created_at).toLocaleDateString()}
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Danger Zone */}
+      <Card className="border-red-200 dark:border-red-900">
+        <CardHeader>
+          <CardTitle className="text-lg text-red-600 dark:text-red-400">Danger Zone</CardTitle>
+          <CardDescription>
+            Irreversible actions for your agency account
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-medium text-gray-900 dark:text-gray-100">
+                Delete Agency
+              </p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Permanently delete your agency and all associated data
+              </p>
+            </div>
+            <Button variant="destructive" disabled>
+              Delete Agency
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/(agency)/agency/team/page.tsx
+++ b/frontend/app/(agency)/agency/team/page.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/lib/auth';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import {
+  UserPlus,
+  MoreVertical,
+  Shield,
+  Crown,
+  User,
+  Trash2,
+  Loader2,
+  RefreshCw,
+} from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Label } from '@/components/ui/label';
+import { agencyApi, type AgencyMember } from '@/lib/agency-api';
+import { toast } from 'sonner';
+
+type MemberRole = 'owner' | 'admin' | 'member';
+
+const roleConfig: Record<MemberRole, { label: string; icon: React.ElementType; color: string }> = {
+  owner: { label: 'Owner', icon: Crown, color: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300' },
+  admin: { label: 'Admin', icon: Shield, color: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300' },
+  member: { label: 'Member', icon: User, color: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300' },
+};
+
+export default function AgencyTeamPage() {
+  const { user } = useAuth();
+  const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteRole, setInviteRole] = useState<'admin' | 'member'>('member');
+  const [isInviting, setIsInviting] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [teamMembers, setTeamMembers] = useState<AgencyMember[]>([]);
+
+  useEffect(() => {
+    fetchTeamMembers();
+  }, []);
+
+  const fetchTeamMembers = async () => {
+    setIsLoading(true);
+    try {
+      const members = await agencyApi.getTeamMembers();
+      setTeamMembers(members);
+    } catch (error) {
+      console.error('Failed to fetch team members:', error);
+      toast.error('Failed to load team members');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleInvite = async () => {
+    if (!inviteEmail) return;
+
+    setIsInviting(true);
+    try {
+      await agencyApi.inviteTeamMember(inviteEmail, inviteRole);
+      toast.success('Invitation sent!');
+      setInviteEmail('');
+      setInviteRole('member');
+      setIsInviteModalOpen(false);
+      fetchTeamMembers();
+    } catch (error: unknown) {
+      const err = error as { response?: { data?: { detail?: string } } };
+      toast.error(err.response?.data?.detail || 'Failed to send invitation');
+    } finally {
+      setIsInviting(false);
+    }
+  };
+
+  const handleRoleChange = async (memberId: string, newRole: 'admin' | 'member') => {
+    try {
+      await agencyApi.updateTeamMemberRole(memberId, newRole);
+      toast.success('Role updated');
+      fetchTeamMembers();
+    } catch (error: unknown) {
+      const err = error as { response?: { data?: { detail?: string } } };
+      toast.error(err.response?.data?.detail || 'Failed to update role');
+    }
+  };
+
+  const handleRemoveMember = async (memberId: string) => {
+    if (!confirm('Are you sure you want to remove this team member?')) {
+      return;
+    }
+    try {
+      await agencyApi.removeTeamMember(memberId);
+      toast.success('Team member removed');
+      fetchTeamMembers();
+    } catch (error: unknown) {
+      const err = error as { response?: { data?: { detail?: string } } };
+      toast.error(err.response?.data?.detail || 'Failed to remove team member');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Team
+          </h1>
+          <p className="mt-1 text-gray-600 dark:text-gray-400">
+            Manage your agency team members
+          </p>
+        </div>
+        <Dialog open={isInviteModalOpen} onOpenChange={setIsInviteModalOpen}>
+          <DialogTrigger asChild>
+            <Button className="bg-green-600 hover:bg-green-700">
+              <UserPlus className="mr-2 h-4 w-4" />
+              Invite Team Member
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Invite Team Member</DialogTitle>
+              <DialogDescription>
+                Add a new team member to help manage your agency. They&apos;ll receive
+                an email invitation.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4 py-4">
+              <div className="space-y-2">
+                <Label htmlFor="email">Email Address</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="team@example.com"
+                  value={inviteEmail}
+                  onChange={(e) => setInviteEmail(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleInvite()}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="role">Role</Label>
+                <Select value={inviteRole} onValueChange={(v) => setInviteRole(v as 'admin' | 'member')}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a role" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="admin">
+                      <div className="flex items-center gap-2">
+                        <Shield className="h-4 w-4" />
+                        Admin - Full access to manage agency
+                      </div>
+                    </SelectItem>
+                    <SelectItem value="member">
+                      <div className="flex items-center gap-2">
+                        <User className="h-4 w-4" />
+                        Member - View and manage creators
+                      </div>
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setIsInviteModalOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handleInvite}
+                disabled={!inviteEmail || isInviting}
+                className="bg-green-600 hover:bg-green-700"
+              >
+                {isInviting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Sending...
+                  </>
+                ) : (
+                  'Send Invitation'
+                )}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {/* Team Members List */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Team Members</CardTitle>
+          <CardDescription>
+            {teamMembers.length} member{teamMembers.length !== 1 ? 's' : ''}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {teamMembers.map((member) => {
+              const role = roleConfig[member.role];
+              const RoleIcon = role.icon;
+              const isCurrentUser = member.user_id === user?.id;
+
+              return (
+                <div
+                  key={member.id}
+                  className="flex items-center justify-between py-3 border-b border-gray-100 dark:border-gray-800 last:border-0"
+                >
+                  <div className="flex items-center gap-4">
+                    <div className="h-10 w-10 rounded-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center text-white font-medium">
+                      {(member.user_full_name || member.user_email).charAt(0).toUpperCase()}
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <h3 className="font-medium text-gray-900 dark:text-gray-100">
+                          {member.user_full_name || 'Unnamed'}
+                        </h3>
+                        {isCurrentUser && (
+                          <span className="text-xs text-gray-500 dark:text-gray-400">(You)</span>
+                        )}
+                      </div>
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        {member.user_email}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Badge className={role.color}>
+                      <RoleIcon className="mr-1 h-3 w-3" />
+                      {role.label}
+                    </Badge>
+                    {member.role !== 'owner' && !isCurrentUser && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon">
+                            <MoreVertical className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          {member.role === 'admin' ? (
+                            <DropdownMenuItem onClick={() => handleRoleChange(member.id, 'member')}>
+                              <User className="mr-2 h-4 w-4" />
+                              Change to Member
+                            </DropdownMenuItem>
+                          ) : (
+                            <DropdownMenuItem onClick={() => handleRoleChange(member.id, 'admin')}>
+                              <Shield className="mr-2 h-4 w-4" />
+                              Promote to Admin
+                            </DropdownMenuItem>
+                          )}
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            className="text-red-600"
+                            onClick={() => handleRemoveMember(member.id)}
+                          >
+                            <Trash2 className="mr-2 h-4 w-4" />
+                            Remove from Team
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Permissions Info */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Role Permissions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            <div className="flex items-start gap-3">
+              <div className="h-8 w-8 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 flex items-center justify-center">
+                <Crown className="h-4 w-4 text-yellow-600" />
+              </div>
+              <div>
+                <h4 className="font-medium text-gray-900 dark:text-gray-100">Owner</h4>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Full access including billing, settings, and team management
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <div className="h-8 w-8 rounded-lg bg-blue-50 dark:bg-blue-900/20 flex items-center justify-center">
+                <Shield className="h-4 w-4 text-blue-600" />
+              </div>
+              <div>
+                <h4 className="font-medium text-gray-900 dark:text-gray-100">Admin</h4>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Manage creators, opportunities, and team members (except owner)
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <div className="h-8 w-8 rounded-lg bg-gray-50 dark:bg-gray-800 flex items-center justify-center">
+                <User className="h-4 w-4 text-gray-600" />
+              </div>
+              <div>
+                <h4 className="font-medium text-gray-900 dark:text-gray-100">Member</h4>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  View and manage creators, create and send opportunities
+                </p>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/(agency)/layout.tsx
+++ b/frontend/app/(agency)/layout.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { useAuth } from '@/lib/auth';
+import { LoadingSpinner } from '@/components/shared/LoadingSpinner';
+import { AgencyLayout } from '@/components/agency/AgencyLayout';
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { isAuthenticated, isLoading, checkAuth, user } = useAuth();
+  const [isAgencyUser, setIsAgencyUser] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    checkAuth();
+  }, [checkAuth]);
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.push('/login');
+    }
+  }, [isLoading, isAuthenticated, router]);
+
+  useEffect(() => {
+    if (isLoading || !isAuthenticated || !user) return;
+
+    // Check if user is an agency user
+    if (user.account_type !== 'agency') {
+      // Not an agency user, redirect to regular dashboard
+      router.push('/dashboard');
+      return;
+    }
+
+    setIsAgencyUser(true);
+
+    // Redirect /agency to /agency main page
+    if (pathname === '/agency' || pathname === '/agency/') {
+      // Already at the right place
+    }
+  }, [isLoading, isAuthenticated, user, pathname, router]);
+
+  if (isLoading || isAgencyUser === null) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <LoadingSpinner size="large" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  if (!isAgencyUser) {
+    return null;
+  }
+
+  return <AgencyLayout>{children}</AgencyLayout>;
+}

--- a/frontend/app/(auth)/signup/agency/page.tsx
+++ b/frontend/app/(auth)/signup/agency/page.tsx
@@ -5,28 +5,48 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useAuth } from '@/lib/auth';
-import { signupSchema, type SignupFormData } from '@/lib/validations/auth';
+import { z } from 'zod';
 import { FormInput } from '@/components/ui/form-input';
 import { LoadingButton } from '@/components/ui/loading-button';
 import { ThemeToggle } from '@/components/shared/ThemeToggle';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { AlertCircle, Eye, EyeOff, CheckCircle } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { AlertCircle, Eye, EyeOff, CheckCircle, Building2, Users } from 'lucide-react';
 import { AxiosError } from 'axios';
 import Image from 'next/image';
 import { motion } from 'framer-motion';
-import { FcGoogle } from 'react-icons/fc';
-import { FaInstagram } from 'react-icons/fa';
+import api from '@/lib/api';
+
+// Agency signup schema
+const agencySignupSchema = z.object({
+  fullName: z.string().min(2, 'Full name must be at least 2 characters'),
+  email: z.string().email('Please enter a valid email address'),
+  password: z.string().min(8, 'Password must be at least 8 characters'),
+  confirmPassword: z.string(),
+  agencyName: z.string().min(2, 'Agency name must be at least 2 characters'),
+  website: z.string().url('Please enter a valid URL').optional().or(z.literal('')),
+}).refine((data) => data.password === data.confirmPassword, {
+  message: "Passwords don't match",
+  path: ['confirmPassword'],
+});
+
+type AgencySignupFormData = z.infer<typeof agencySignupSchema>;
 
 interface ErrorResponse {
   detail?: string;
   message?: string;
 }
 
-export default function SignupPage() {
+interface AgencySignupResponse {
+  user_id: string;
+  agency_id: string;
+  agency_slug: string;
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+}
+
+export default function AgencySignupPage() {
   const router = useRouter();
-  const { signup } = useAuth();
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [serverError, setServerError] = useState('');
@@ -36,26 +56,36 @@ export default function SignupPage() {
     handleSubmit,
     watch,
     formState: { errors, isSubmitting },
-  } = useForm<SignupFormData>({
-    resolver: zodResolver(signupSchema),
+  } = useForm<AgencySignupFormData>({
+    resolver: zodResolver(agencySignupSchema),
   });
   const password = watch('password');
 
-  const onSubmit = async (data: SignupFormData) => {
+  const onSubmit = async (data: AgencySignupFormData) => {
     setServerError('');
 
     try {
-      await signup(data.email, data.password, data.fullName);
-      
-      // Redirect to onboarding flow (account type selection)
-      router.push('/onboarding/account-type');
+      const response = await api.post<AgencySignupResponse>('/agency/signup', {
+        email: data.email,
+        password: data.password,
+        full_name: data.fullName,
+        agency_name: data.agencyName,
+        website: data.website || null,
+      });
+
+      // Store tokens
+      localStorage.setItem('access_token', response.data.access_token);
+      localStorage.setItem('refresh_token', response.data.refresh_token);
+
+      // Redirect to agency dashboard
+      router.push('/agency');
     } catch (err) {
-      console.error('Signup error:', err);
+      console.error('Agency signup error:', err);
       const axiosError = err as AxiosError<ErrorResponse>;
       setServerError(
-        axiosError.response?.data?.detail || 
-        axiosError.response?.data?.message || 
-        'Failed to create account. Please try again.'
+        axiosError.response?.data?.detail ||
+        axiosError.response?.data?.message ||
+        'Failed to create agency account. Please try again.'
       );
     }
   };
@@ -63,7 +93,7 @@ export default function SignupPage() {
   // Password strength indicators
   const getPasswordStrength = (password: string) => {
     if (!password) return { score: 0, text: '', color: '' };
-    
+
     let score = 0;
     const checks = [
       password.length >= 8,
@@ -72,9 +102,9 @@ export default function SignupPage() {
       /\d/.test(password),
       /[!@#$%^&*(),.?":{}|<>]/.test(password),
     ];
-    
+
     score = checks.filter(Boolean).length;
-    
+
     if (score < 3) return { score, text: 'Weak', color: 'text-red-500' };
     if (score < 4) return { score, text: 'Fair', color: 'text-yellow-500' };
     if (score < 5) return { score, text: 'Good', color: 'text-blue-500' };
@@ -88,7 +118,7 @@ export default function SignupPage() {
       <div className="absolute top-4 right-4">
         <ThemeToggle />
       </div>
-      
+
       <div className="absolute top-4 left-4">
         <Link href="/" className="flex items-center gap-2 bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm px-3 py-2 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300 hover:bg-white dark:hover:bg-gray-800 transition-all duration-200 group">
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="group-hover:-translate-x-1 transition-transform duration-200">
@@ -98,15 +128,15 @@ export default function SignupPage() {
           <span className="text-sm font-semibold">Back to Home</span>
         </Link>
       </div>
-      
-      <motion.div 
+
+      <motion.div
         className="max-w-md w-full"
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
         {/* Header */}
-        <motion.div 
+        <motion.div
           className="text-center mb-4 w-full max-w-md mx-auto"
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}
@@ -118,9 +148,12 @@ export default function SignupPage() {
               <Image src="/logo/text_dark.png" alt="Repruv" width={180} height={48} className="h-12 w-auto hidden dark:inline" priority />
             </div>
           </Link>
-          <h2 className="mt-6 text-4xl font-extrabold text-primary-dark bg-gradient-to-r from-green-600 to-green-500 dark:from-green-500 dark:to-green-400 bg-clip-text text-transparent">
-            Create Your Account
-          </h2>
+          <div className="mt-6 flex items-center justify-center gap-2">
+            <Building2 className="h-8 w-8 text-green-600 dark:text-green-500" />
+            <h2 className="text-4xl font-extrabold text-primary-dark bg-gradient-to-r from-green-600 to-green-500 dark:from-green-500 dark:to-green-400 bg-clip-text text-transparent">
+              Agency Signup
+            </h2>
+          </div>
           <p className="mt-2 text-base text-secondary-dark">
             Already have an account?{' '}
             <Link
@@ -131,31 +164,53 @@ export default function SignupPage() {
             </Link>
           </p>
           <p className="mt-1 text-sm text-secondary-dark">
-            Are you an agency?{' '}
+            Are you a creator?{' '}
             <Link
-              href="/signup/agency"
+              href="/signup"
               className="font-semibold brand-text hover:underline"
             >
-              Sign up as an agency
+              Sign up as a creator
             </Link>
           </p>
+        </motion.div>
+
+        {/* Benefits Banner */}
+        <motion.div
+          className="mb-4 p-4 bg-gradient-to-r from-green-50 to-emerald-50 dark:from-green-900/20 dark:to-emerald-900/20 rounded-lg border border-green-200 dark:border-green-800"
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.5, delay: 0.2 }}
+        >
+          <div className="flex items-start gap-3">
+            <Users className="h-5 w-5 text-green-600 dark:text-green-400 mt-0.5 flex-shrink-0" />
+            <div>
+              <h3 className="font-semibold text-green-800 dark:text-green-300 text-sm">
+                Agency Benefits
+              </h3>
+              <ul className="mt-1 text-xs text-green-700 dark:text-green-400 space-y-1">
+                <li>• Manage all your creators in one place</li>
+                <li>• Push sponsorship opportunities directly to creators</li>
+                <li>• View aggregated analytics for brand pitches</li>
+              </ul>
+            </div>
+          </div>
         </motion.div>
 
         {/* Signup Form */}
         <Card className="card-background border-gray-200/50 dark:border-gray-800/50 shadow-lg backdrop-blur-sm overflow-hidden">
           <CardHeader className="space-y-1 py-4 bg-gradient-to-r from-white/40 to-white/20 dark:from-gray-900/40 dark:to-gray-900/20">
             <CardTitle className="text-xl text-center text-gray-800 dark:text-gray-200">
-              Get started
+              Create Your Agency
             </CardTitle>
             <CardDescription className="text-center text-sm text-gray-600 dark:text-gray-400">
-              Enter your credentials to unlock your AI-powered community engagement tools
+              Set up your agency account and start managing creators
             </CardDescription>
           </CardHeader>
           <CardContent className="pt-4">
             <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
               {/* Server Error */}
               {serverError && (
-                <motion.div 
+                <motion.div
                   className="flex items-center space-x-2 text-red-600 bg-red-50 dark:bg-red-900/20 p-3 rounded-md"
                   initial={{ opacity: 0, x: -20 }}
                   animate={{ opacity: 1, x: 0 }}
@@ -166,12 +221,24 @@ export default function SignupPage() {
                 </motion.div>
               )}
 
+              {/* Agency Name Field */}
+              <FormInput
+                {...register('agencyName')}
+                id="agencyName"
+                type="text"
+                label="Agency name"
+                placeholder="Your Agency Name"
+                error={errors.agencyName?.message}
+                autoComplete="organization"
+                className="focus:border-green-500 focus:ring-green-500/20 transition-all duration-300"
+              />
+
               {/* Full Name Field */}
               <FormInput
                 {...register('fullName')}
                 id="fullName"
                 type="text"
-                label="Full name"
+                label="Your name"
                 placeholder="Enter your full name"
                 error={errors.fullName?.message}
                 autoComplete="name"
@@ -187,6 +254,18 @@ export default function SignupPage() {
                 placeholder="Enter your email"
                 error={errors.email?.message}
                 autoComplete="email"
+                className="focus:border-green-500 focus:ring-green-500/20 transition-all duration-300"
+              />
+
+              {/* Website Field */}
+              <FormInput
+                {...register('website')}
+                id="website"
+                type="url"
+                label="Agency website (optional)"
+                placeholder="https://youragency.com"
+                error={errors.website?.message}
+                autoComplete="url"
                 className="focus:border-green-500 focus:ring-green-500/20 transition-all duration-300"
               />
 
@@ -216,10 +295,10 @@ export default function SignupPage() {
                     )}
                   </button>
                 </div>
-                
+
                 {/* Password Strength Indicator */}
                 {password && (
-                  <motion.div 
+                  <motion.div
                     className="space-y-1"
                     initial={{ opacity: 0, height: 0 }}
                     animate={{ opacity: 1, height: 'auto' }}
@@ -228,11 +307,10 @@ export default function SignupPage() {
                     <div className="flex items-center space-x-2">
                       <div className="flex-1 section-background-alt rounded-full h-2">
                         <div
-                          className={`h-2 rounded-full transition-all duration-300 ${
-                            passwordStrength.score < 3 ? 'status-danger-bg' :
+                          className={`h-2 rounded-full transition-all duration-300 ${passwordStrength.score < 3 ? 'status-danger-bg' :
                             passwordStrength.score < 4 ? 'status-warning-bg' :
-                            passwordStrength.score < 5 ? 'status-info-bg' : 'status-success-bg'
-                          }`}
+                              passwordStrength.score < 5 ? 'status-info-bg' : 'status-success-bg'
+                            }`}
                           style={{ width: `${(passwordStrength.score / 5) * 100}%` }}
                         />
                       </div>
@@ -308,58 +386,9 @@ export default function SignupPage() {
                 className="w-full bg-gradient-to-r from-green-600 to-green-500 hover:from-green-700 hover:to-green-600 text-white font-semibold py-2.5 rounded-lg shadow-md hover:shadow-lg transition-all duration-300 transform hover:-translate-y-0.5"
                 variant="default"
               >
-                {isSubmitting ? 'Creating account...' : 'Create account'}
+                {isSubmitting ? 'Creating agency...' : 'Create Agency Account'}
               </LoadingButton>
             </form>
-            
-            {/* Social Login Divider */}
-            <div className="relative my-3">
-              <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-gray-300 dark:border-gray-700"></div>
-              </div>
-              <div className="relative flex justify-center text-xs">
-                <span className="px-2 bg-white dark:bg-gray-900 text-gray-500 dark:text-gray-400">
-                  Or sign up with
-                </span>
-              </div>
-            </div>
-            
-            {/* Social Login Buttons */}
-            <div className="grid grid-cols-2 gap-3">
-              <Button 
-                variant="outline"
-                className="flex items-center justify-center gap-2 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-300"
-                type="button"
-                onClick={async () => {
-                  try {
-                    await useAuth.getState().googleLogin();
-                  } catch (error) {
-                    console.error('Failed to sign up with Google:', error);
-                    setServerError('Failed to sign up with Google. Please try again.');
-                  }
-                }}
-              >
-                <FcGoogle className="w-5 h-5" />
-                <span className="text-gray-700 dark:text-gray-300">Google</span>
-              </Button>
-              <Button 
-                variant="outline"
-                className="flex items-center justify-center gap-2 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-300"
-                type="button"
-                onClick={async () => {
-                  try {
-                    await useAuth.getState().instagramLogin();
-                  } catch (error) {
-                    console.error('Failed to sign up with Instagram:', error);
-                    setServerError('Failed to sign up with Instagram. Please try again.');
-                  }
-                }}
-              >
-                <FaInstagram className="w-5 h-5 text-pink-600" />
-                <span className="text-gray-700 dark:text-gray-300">Instagram</span>
-              </Button>
-            </div>
-
           </CardContent>
         </Card>
       </motion.div>

--- a/frontend/app/(dashboard)/dashboard/opportunities/[id]/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/opportunities/[id]/page.tsx
@@ -1,0 +1,437 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import {
+  Building2,
+  DollarSign,
+  Calendar,
+  Clock,
+  CheckCircle,
+  XCircle,
+  Eye,
+  Send,
+  ArrowLeft,
+  ExternalLink,
+  FileText,
+  ListChecks,
+  AlertCircle,
+  Loader2,
+} from 'lucide-react';
+import { api } from '@/lib/api';
+
+interface OpportunityDetail {
+  id: string;
+  agency_id: string;
+  agency_name: string;
+  agency_logo_url: string | null;
+  title: string;
+  brand_name: string;
+  brand_logo_url: string | null;
+  description: string;
+  requirements: {
+    deliverables?: string[];
+    content_guidelines?: string;
+    talking_points?: string[];
+    restrictions?: string[];
+  };
+  compensation: {
+    type?: string;
+    amount?: number;
+    currency?: string;
+    payment_terms?: string;
+    product_value?: number;
+    notes?: string;
+  };
+  deadline: string | null;
+  content_deadline: string | null;
+  status: 'sent' | 'viewed' | 'accepted' | 'declined' | 'completed' | 'cancelled';
+  sent_at: string | null;
+  viewed_at: string | null;
+  project_id: string | null;
+  created_at: string;
+}
+
+const statusConfig = {
+  sent: { label: 'New', color: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400', icon: Send },
+  viewed: { label: 'Viewed', color: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400', icon: Eye },
+  accepted: { label: 'Accepted', color: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400', icon: CheckCircle },
+  declined: { label: 'Declined', color: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400', icon: XCircle },
+  completed: { label: 'Completed', color: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300', icon: CheckCircle },
+  cancelled: { label: 'Cancelled', color: 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-500', icon: XCircle },
+};
+
+export default function OpportunityDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const [opportunity, setOpportunity] = useState<OpportunityDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<'accept' | 'decline' | null>(null);
+  const [notes, setNotes] = useState('');
+  const [showDeclineModal, setShowDeclineModal] = useState(false);
+
+  useEffect(() => {
+    if (params.id) {
+      loadOpportunity();
+    }
+  }, [params.id]);
+
+  const loadOpportunity = async () => {
+    try {
+      setLoading(true);
+      const data = await api.get(`/creator/opportunities/${params.id}`);
+      setOpportunity(data);
+    } catch (error) {
+      console.error('Failed to load opportunity:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAccept = async () => {
+    try {
+      setActionLoading('accept');
+      await api.post(`/creator/opportunities/${params.id}/accept`, {
+        notes: notes || undefined,
+      });
+      router.push('/dashboard/opportunities');
+    } catch (error) {
+      console.error('Failed to accept opportunity:', error);
+      alert('Failed to accept opportunity. Please try again.');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleDecline = async () => {
+    try {
+      setActionLoading('decline');
+      await api.post(`/creator/opportunities/${params.id}/decline`, {
+        reason: notes || undefined,
+      });
+      router.push('/dashboard/opportunities');
+    } catch (error) {
+      console.error('Failed to decline opportunity:', error);
+      alert('Failed to decline opportunity. Please try again.');
+    } finally {
+      setActionLoading(null);
+      setShowDeclineModal(false);
+    }
+  };
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return null;
+    return new Date(dateString).toLocaleDateString('en-US', {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  const formatCurrency = (amount: number | undefined, currency: string = 'USD') => {
+    if (!amount) return null;
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  };
+
+  if (loading) {
+    return (
+      <div className="p-6 max-w-4xl mx-auto">
+        <div className="dashboard-card p-12 text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600 mx-auto"></div>
+          <p className="text-secondary-dark mt-4">Loading opportunity...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!opportunity) {
+    return (
+      <div className="p-6 max-w-4xl mx-auto">
+        <div className="dashboard-card p-12 text-center">
+          <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
+          <h3 className="text-lg font-semibold text-primary-dark mb-2">Opportunity not found</h3>
+          <p className="text-secondary-dark mb-4">This opportunity may have been removed or you don&apos;t have access.</p>
+          <Link
+            href="/dashboard/opportunities"
+            className="inline-flex items-center text-green-600 hover:text-green-700"
+          >
+            <ArrowLeft className="h-4 w-4 mr-1" />
+            Back to opportunities
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const config = statusConfig[opportunity.status];
+  const StatusIcon = config.icon;
+  const canRespond = ['sent', 'viewed'].includes(opportunity.status);
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      {/* Header */}
+      <div className="mb-6">
+        <Link
+          href="/dashboard/opportunities"
+          className="inline-flex items-center text-sm text-secondary-dark hover:text-primary-dark mb-4"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" />
+          Back to Opportunities
+        </Link>
+      </div>
+
+      {/* Main Card */}
+      <div className="dashboard-card p-8 mb-6">
+        {/* Status & Agency */}
+        <div className="flex items-center gap-3 mb-4">
+          <span className={`inline-flex items-center gap-1 px-3 py-1 text-sm font-medium rounded-full ${config.color}`}>
+            <StatusIcon className="h-4 w-4" />
+            {config.label}
+          </span>
+          <span className="text-secondary-dark flex items-center gap-1">
+            <Building2 className="h-4 w-4" />
+            From {opportunity.agency_name}
+          </span>
+        </div>
+
+        {/* Title & Brand */}
+        <h1 className="text-2xl font-bold text-primary-dark mb-2">{opportunity.title}</h1>
+        <p className="text-lg text-secondary-dark flex items-center gap-2 mb-6">
+          <DollarSign className="h-5 w-5" />
+          Brand: <span className="font-semibold text-primary-dark">{opportunity.brand_name}</span>
+        </p>
+
+        {/* Dates */}
+        <div className="flex flex-wrap gap-6 mb-8 text-sm">
+          {opportunity.sent_at && (
+            <div className="flex items-center gap-2 text-secondary-dark">
+              <Clock className="h-4 w-4" />
+              <span>Received: {formatDate(opportunity.sent_at)}</span>
+            </div>
+          )}
+          {opportunity.deadline && (
+            <div className="flex items-center gap-2 text-orange-600 dark:text-orange-400">
+              <Calendar className="h-4 w-4" />
+              <span>Response Due: {formatDate(opportunity.deadline)}</span>
+            </div>
+          )}
+          {opportunity.content_deadline && (
+            <div className="flex items-center gap-2 text-secondary-dark">
+              <FileText className="h-4 w-4" />
+              <span>Content Due: {formatDate(opportunity.content_deadline)}</span>
+            </div>
+          )}
+        </div>
+
+        {/* Description */}
+        <div className="mb-8">
+          <h2 className="text-lg font-semibold text-primary-dark mb-3">Description</h2>
+          <div className="prose dark:prose-invert max-w-none">
+            <p className="text-secondary-dark whitespace-pre-wrap">{opportunity.description}</p>
+          </div>
+        </div>
+
+        {/* Compensation */}
+        {opportunity.compensation && Object.keys(opportunity.compensation).length > 0 && (
+          <div className="mb-8 p-6 bg-green-50 dark:bg-green-900/20 rounded-xl border border-green-100 dark:border-green-800">
+            <h2 className="text-lg font-semibold text-green-800 dark:text-green-200 mb-4 flex items-center gap-2">
+              <DollarSign className="h-5 w-5" />
+              Compensation
+            </h2>
+            <div className="grid md:grid-cols-2 gap-4">
+              {opportunity.compensation.amount && (
+                <div>
+                  <p className="text-sm text-green-700 dark:text-green-300">Payment</p>
+                  <p className="text-2xl font-bold text-green-800 dark:text-green-100">
+                    {formatCurrency(opportunity.compensation.amount, opportunity.compensation.currency)}
+                  </p>
+                </div>
+              )}
+              {opportunity.compensation.product_value && (
+                <div>
+                  <p className="text-sm text-green-700 dark:text-green-300">Product Value</p>
+                  <p className="text-lg font-semibold text-green-800 dark:text-green-100">
+                    {formatCurrency(opportunity.compensation.product_value, opportunity.compensation.currency)}
+                  </p>
+                </div>
+              )}
+              {opportunity.compensation.payment_terms && (
+                <div className="md:col-span-2">
+                  <p className="text-sm text-green-700 dark:text-green-300">Payment Terms</p>
+                  <p className="text-green-800 dark:text-green-100">{opportunity.compensation.payment_terms}</p>
+                </div>
+              )}
+              {opportunity.compensation.notes && (
+                <div className="md:col-span-2">
+                  <p className="text-sm text-green-700 dark:text-green-300">Notes</p>
+                  <p className="text-green-800 dark:text-green-100">{opportunity.compensation.notes}</p>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Requirements */}
+        {opportunity.requirements && Object.keys(opportunity.requirements).length > 0 && (
+          <div className="mb-8">
+            <h2 className="text-lg font-semibold text-primary-dark mb-4 flex items-center gap-2">
+              <ListChecks className="h-5 w-5" />
+              Requirements
+            </h2>
+
+            {opportunity.requirements.deliverables && opportunity.requirements.deliverables.length > 0 && (
+              <div className="mb-4">
+                <h3 className="text-sm font-medium text-secondary-dark mb-2">Deliverables</h3>
+                <ul className="space-y-2">
+                  {opportunity.requirements.deliverables.map((item, i) => (
+                    <li key={i} className="flex items-start gap-2 text-primary-dark">
+                      <CheckCircle className="h-4 w-4 text-green-500 mt-0.5 flex-shrink-0" />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {opportunity.requirements.talking_points && opportunity.requirements.talking_points.length > 0 && (
+              <div className="mb-4">
+                <h3 className="text-sm font-medium text-secondary-dark mb-2">Key Talking Points</h3>
+                <ul className="space-y-2">
+                  {opportunity.requirements.talking_points.map((item, i) => (
+                    <li key={i} className="flex items-start gap-2 text-primary-dark">
+                      <span className="text-green-500">-</span>
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {opportunity.requirements.content_guidelines && (
+              <div className="mb-4">
+                <h3 className="text-sm font-medium text-secondary-dark mb-2">Content Guidelines</h3>
+                <p className="text-primary-dark">{opportunity.requirements.content_guidelines}</p>
+              </div>
+            )}
+
+            {opportunity.requirements.restrictions && opportunity.requirements.restrictions.length > 0 && (
+              <div className="mb-4">
+                <h3 className="text-sm font-medium text-secondary-dark mb-2">Restrictions</h3>
+                <ul className="space-y-2">
+                  {opportunity.requirements.restrictions.map((item, i) => (
+                    <li key={i} className="flex items-start gap-2 text-red-600 dark:text-red-400">
+                      <XCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Actions */}
+        {canRespond && (
+          <div className="border-t pt-6">
+            <h2 className="text-lg font-semibold text-primary-dark mb-4">Your Response</h2>
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-secondary-dark mb-2">
+                Add a note (optional)
+              </label>
+              <textarea
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Add any notes or questions for your agency..."
+                className="w-full p-3 border rounded-lg bg-white dark:bg-gray-800 text-primary-dark resize-none"
+                rows={3}
+              />
+            </div>
+            <div className="flex gap-4">
+              <button
+                onClick={handleAccept}
+                disabled={!!actionLoading}
+                className="flex-1 py-3 px-6 bg-green-600 hover:bg-green-700 text-white rounded-lg font-semibold transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+              >
+                {actionLoading === 'accept' ? (
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                ) : (
+                  <CheckCircle className="h-5 w-5" />
+                )}
+                Accept Opportunity
+              </button>
+              <button
+                onClick={() => setShowDeclineModal(true)}
+                disabled={!!actionLoading}
+                className="py-3 px-6 border border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg font-semibold transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+              >
+                <XCircle className="h-5 w-5" />
+                Decline
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Project Link */}
+        {opportunity.project_id && opportunity.status === 'accepted' && (
+          <div className="border-t pt-6">
+            <Link
+              href={`/monetization/project/${opportunity.project_id}`}
+              className="inline-flex items-center gap-2 text-green-600 hover:text-green-700 font-semibold"
+            >
+              <ExternalLink className="h-5 w-5" />
+              Go to Project
+            </Link>
+          </div>
+        )}
+      </div>
+
+      {/* Decline Modal */}
+      {showDeclineModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white dark:bg-gray-900 rounded-xl p-6 max-w-md w-full">
+            <h3 className="text-lg font-semibold text-primary-dark mb-4">Decline Opportunity?</h3>
+            <p className="text-secondary-dark mb-4">
+              Are you sure you want to decline this opportunity? Your agency will be notified.
+            </p>
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-secondary-dark mb-2">
+                Reason (optional)
+              </label>
+              <textarea
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Let your agency know why you're declining..."
+                className="w-full p-3 border rounded-lg bg-white dark:bg-gray-800 text-primary-dark resize-none"
+                rows={3}
+              />
+            </div>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowDeclineModal(false)}
+                className="flex-1 py-2 px-4 border rounded-lg text-secondary-dark hover:bg-gray-50 dark:hover:bg-gray-800"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDecline}
+                disabled={actionLoading === 'decline'}
+                className="flex-1 py-2 px-4 bg-red-600 hover:bg-red-700 text-white rounded-lg font-semibold disabled:opacity-50 flex items-center justify-center gap-2"
+              >
+                {actionLoading === 'decline' ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : null}
+                Decline
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/dashboard/opportunities/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/opportunities/page.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import {
+  Building2,
+  DollarSign,
+  Calendar,
+  Clock,
+  CheckCircle,
+  XCircle,
+  Eye,
+  Send,
+  ChevronRight,
+  Briefcase,
+  ArrowLeft,
+} from 'lucide-react';
+import { api } from '@/lib/api';
+
+interface Opportunity {
+  id: string;
+  agency_name: string;
+  title: string;
+  brand_name: string;
+  status: 'sent' | 'viewed' | 'accepted' | 'declined' | 'completed' | 'cancelled';
+  deadline: string | null;
+  sent_at: string | null;
+}
+
+interface OpportunityCounts {
+  pending: number;
+  accepted: number;
+  declined: number;
+  completed: number;
+  total: number;
+}
+
+const statusConfig = {
+  sent: { label: 'New', color: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400', icon: Send },
+  viewed: { label: 'Viewed', color: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400', icon: Eye },
+  accepted: { label: 'Accepted', color: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400', icon: CheckCircle },
+  declined: { label: 'Declined', color: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400', icon: XCircle },
+  completed: { label: 'Completed', color: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300', icon: CheckCircle },
+  cancelled: { label: 'Cancelled', color: 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-500', icon: XCircle },
+};
+
+export default function CreatorOpportunitiesPage() {
+  const router = useRouter();
+  const [opportunities, setOpportunities] = useState<Opportunity[]>([]);
+  const [counts, setCounts] = useState<OpportunityCounts | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<'pending' | 'all'>('pending');
+
+  useEffect(() => {
+    loadOpportunities();
+    loadCounts();
+  }, [activeTab]);
+
+  const loadOpportunities = async () => {
+    try {
+      setLoading(true);
+      const endpoint = activeTab === 'pending'
+        ? '/creator/opportunities/pending'
+        : '/creator/opportunities/';
+      const data = await api.get(endpoint);
+      setOpportunities(data);
+    } catch (error) {
+      console.error('Failed to load opportunities:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadCounts = async () => {
+    try {
+      const data = await api.get('/creator/opportunities/count');
+      setCounts(data);
+    } catch (error) {
+      console.error('Failed to load counts:', error);
+    }
+  };
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return 'No deadline';
+    return new Date(dateString).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      {/* Header */}
+      <div className="mb-8">
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center text-sm text-secondary-dark hover:text-primary-dark mb-4"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" />
+          Back to Dashboard
+        </Link>
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-primary-dark">Sponsorship Opportunities</h1>
+            <p className="text-secondary-dark mt-1">
+              Opportunities from your agency for brand partnerships
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Stats Cards */}
+      {counts && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+          <div className="dashboard-card p-4">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg">
+                <Send className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold text-primary-dark">{counts.pending}</p>
+                <p className="text-sm text-secondary-dark">Pending</p>
+              </div>
+            </div>
+          </div>
+          <div className="dashboard-card p-4">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-green-100 dark:bg-green-900/30 rounded-lg">
+                <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold text-primary-dark">{counts.accepted}</p>
+                <p className="text-sm text-secondary-dark">Accepted</p>
+              </div>
+            </div>
+          </div>
+          <div className="dashboard-card p-4">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-gray-100 dark:bg-gray-800 rounded-lg">
+                <CheckCircle className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold text-primary-dark">{counts.completed}</p>
+                <p className="text-sm text-secondary-dark">Completed</p>
+              </div>
+            </div>
+          </div>
+          <div className="dashboard-card p-4">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-purple-100 dark:bg-purple-900/30 rounded-lg">
+                <Briefcase className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold text-primary-dark">{counts.total}</p>
+                <p className="text-sm text-secondary-dark">Total</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Tabs */}
+      <div className="flex gap-2 mb-6">
+        <button
+          onClick={() => setActiveTab('pending')}
+          className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+            activeTab === 'pending'
+              ? 'brand-background brand-text'
+              : 'bg-gray-100 dark:bg-gray-800 text-secondary-dark hover:text-primary-dark'
+          }`}
+        >
+          Pending Review
+          {counts && counts.pending > 0 && (
+            <span className="ml-2 px-2 py-0.5 text-xs rounded-full bg-white/20">{counts.pending}</span>
+          )}
+        </button>
+        <button
+          onClick={() => setActiveTab('all')}
+          className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+            activeTab === 'all'
+              ? 'brand-background brand-text'
+              : 'bg-gray-100 dark:bg-gray-800 text-secondary-dark hover:text-primary-dark'
+          }`}
+        >
+          All Opportunities
+        </button>
+      </div>
+
+      {/* Opportunities List */}
+      {loading ? (
+        <div className="dashboard-card p-12 text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600 mx-auto"></div>
+          <p className="text-secondary-dark mt-4">Loading opportunities...</p>
+        </div>
+      ) : opportunities.length === 0 ? (
+        <div className="dashboard-card p-12 text-center">
+          <div className="w-16 h-16 bg-gray-100 dark:bg-gray-800 rounded-full flex items-center justify-center mx-auto mb-4">
+            <Briefcase className="h-8 w-8 text-gray-400" />
+          </div>
+          <h3 className="text-lg font-semibold text-primary-dark mb-2">
+            {activeTab === 'pending' ? 'No pending opportunities' : 'No opportunities yet'}
+          </h3>
+          <p className="text-secondary-dark max-w-md mx-auto">
+            {activeTab === 'pending'
+              ? "You're all caught up! Check back later for new opportunities from your agency."
+              : "Your agency hasn't sent you any opportunities yet. They'll appear here when they do."}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {opportunities.map((opp) => {
+            const config = statusConfig[opp.status];
+            const StatusIcon = config.icon;
+
+            return (
+              <Link
+                key={opp.id}
+                href={`/dashboard/opportunities/${opp.id}`}
+                className="dashboard-card p-6 block hover:border-green-200 dark:hover:border-green-800 transition-colors group"
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-3 mb-2">
+                      <span className={`inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full ${config.color}`}>
+                        <StatusIcon className="h-3 w-3" />
+                        {config.label}
+                      </span>
+                      <span className="text-sm text-secondary-dark flex items-center gap-1">
+                        <Building2 className="h-3.5 w-3.5" />
+                        {opp.agency_name}
+                      </span>
+                    </div>
+
+                    <h3 className="text-lg font-semibold text-primary-dark group-hover:text-green-600 transition-colors mb-1">
+                      {opp.title}
+                    </h3>
+
+                    <div className="flex items-center gap-4 text-sm text-secondary-dark">
+                      <span className="flex items-center gap-1">
+                        <DollarSign className="h-4 w-4" />
+                        {opp.brand_name}
+                      </span>
+                      {opp.deadline && (
+                        <span className="flex items-center gap-1">
+                          <Calendar className="h-4 w-4" />
+                          Due: {formatDate(opp.deadline)}
+                        </span>
+                      )}
+                      {opp.sent_at && (
+                        <span className="flex items-center gap-1">
+                          <Clock className="h-4 w-4" />
+                          Received: {formatDate(opp.sent_at)}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  <ChevronRight className="h-5 w-5 text-gray-400 group-hover:text-green-600 transition-colors flex-shrink-0" />
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -8,6 +8,8 @@ import Link from 'next/link';
 import AutomationImpactWidget from '@/components/intelligence/AutomationImpactWidget';
 import { features } from '@/lib/features';
 import { PlatformConnectionButton } from '@/components/integrations/PlatformConnectionButton';
+import { AgencyBadge } from '@/components/agency/AgencyBadge';
+import { AgencyInvitationsBanner } from '@/components/agency/AgencyInvitationsBanner';
 import { Youtube, Instagram, Music, TrendingUp, Users, MessageCircle, Zap, Sparkles, Settings2 } from 'lucide-react';
 
 interface DashboardMetrics {
@@ -145,6 +147,12 @@ export default function DashboardPage() {
           </div>
         </div>
       )}
+
+      {/* Agency Invitations Banner - Show pending invitations */}
+      <AgencyInvitationsBanner />
+
+      {/* Agency Badge - Show if creator is part of an agency */}
+      <AgencyBadge />
 
       {/* Header Section - Gradient Text */}
       <div className="space-y-3">

--- a/frontend/components/agency/AgencyBadge.tsx
+++ b/frontend/components/agency/AgencyBadge.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import {
+  Building2,
+  ChevronRight,
+  LogOut,
+  Briefcase,
+  Bell,
+  X,
+  Loader2,
+} from 'lucide-react';
+import { creatorAgencyApi, creatorOpportunityApi, CreatorAgency, CreatorOpportunityCounts } from '@/lib/agency-api';
+
+export function AgencyBadge() {
+  const [agency, setAgency] = useState<CreatorAgency | null>(null);
+  const [opportunityCounts, setOpportunityCounts] = useState<CreatorOpportunityCounts | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [showLeaveModal, setShowLeaveModal] = useState(false);
+  const [leaving, setLeaving] = useState(false);
+
+  useEffect(() => {
+    loadAgencyData();
+  }, []);
+
+  const loadAgencyData = async () => {
+    try {
+      setLoading(true);
+      const [agencyData, counts] = await Promise.all([
+        creatorAgencyApi.getMyAgency(),
+        creatorOpportunityApi.getCounts().catch(() => null),
+      ]);
+      setAgency(agencyData);
+      setOpportunityCounts(counts);
+    } catch (error) {
+      console.error('Failed to load agency data:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleLeaveAgency = async () => {
+    try {
+      setLeaving(true);
+      await creatorAgencyApi.leaveAgency();
+      setAgency(null);
+      setShowLeaveModal(false);
+    } catch (error) {
+      console.error('Failed to leave agency:', error);
+      alert('Failed to leave agency. Please try again.');
+    } finally {
+      setLeaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="glass-panel rounded-2xl border border-holo-purple/20 p-6 shadow-glass backdrop-blur-md animate-pulse">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-xl bg-gray-200 dark:bg-gray-700" />
+          <div className="flex-1">
+            <div className="h-4 w-24 bg-gray-200 dark:bg-gray-700 rounded mb-2" />
+            <div className="h-3 w-32 bg-gray-200 dark:bg-gray-700 rounded" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!agency) {
+    return null;
+  }
+
+  const pendingCount = opportunityCounts?.pending || 0;
+
+  return (
+    <>
+      <div className="glass-panel rounded-2xl border border-holo-purple/20 p-6 shadow-glass backdrop-blur-md">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-3">
+            {agency.agency_logo_url ? (
+              <img
+                src={agency.agency_logo_url}
+                alt={agency.agency_name}
+                className="w-10 h-10 rounded-xl object-cover"
+              />
+            ) : (
+              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-holo-purple/20 to-holo-purple-light/20 border border-holo-purple/30 flex items-center justify-center">
+                <Building2 className="h-5 w-5 text-holo-purple" />
+              </div>
+            )}
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="font-semibold text-foreground">{agency.agency_name}</span>
+                <span className="text-xs px-2 py-0.5 rounded-full bg-holo-purple/20 text-holo-purple font-medium">
+                  Agency
+                </span>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                You're represented by this agency
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={() => setShowLeaveModal(true)}
+            className="p-2 rounded-lg text-muted-foreground hover:text-rose-500 hover:bg-rose-500/10 transition-colors"
+            title="Leave agency"
+          >
+            <LogOut className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Opportunities Section */}
+        <div className="space-y-2">
+          <Link
+            href="/dashboard/opportunities"
+            className="flex items-center justify-between p-3 rounded-xl bg-gradient-to-r from-holo-purple/10 to-transparent hover:from-holo-purple/20 transition-colors group"
+          >
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-lg bg-holo-purple/20">
+                <Briefcase className="h-4 w-4 text-holo-purple" />
+              </div>
+              <span className="font-medium text-foreground">Sponsorship Opportunities</span>
+            </div>
+            <div className="flex items-center gap-2">
+              {pendingCount > 0 && (
+                <span className="flex items-center gap-1 px-2 py-1 rounded-full bg-holo-pink/20 text-holo-pink text-xs font-semibold">
+                  <Bell className="h-3 w-3" />
+                  {pendingCount} pending
+                </span>
+              )}
+              <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:text-holo-purple transition-colors" />
+            </div>
+          </Link>
+        </div>
+      </div>
+
+      {/* Leave Agency Modal */}
+      {showLeaveModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl max-w-md w-full p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold text-foreground">Leave Agency</h3>
+              <button
+                onClick={() => setShowLeaveModal(false)}
+                className="p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+              >
+                <X className="h-5 w-5 text-muted-foreground" />
+              </button>
+            </div>
+            <p className="text-muted-foreground mb-6">
+              Are you sure you want to leave <span className="font-semibold text-foreground">{agency.agency_name}</span>?
+              You will no longer receive opportunities from them and any pending opportunities will be cancelled.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowLeaveModal(false)}
+                disabled={leaving}
+                className="flex-1 px-4 py-2 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded-lg font-medium hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleLeaveAgency}
+                disabled={leaving}
+                className="flex-1 px-4 py-2 bg-rose-600 hover:bg-rose-700 text-white rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
+              >
+                {leaving ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Leaving...
+                  </>
+                ) : (
+                  <>
+                    <LogOut className="h-4 w-4" />
+                    Leave Agency
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/components/agency/AgencyInvitationsBanner.tsx
+++ b/frontend/components/agency/AgencyInvitationsBanner.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import {
+  Building2,
+  Check,
+  X,
+  Loader2,
+  ChevronDown,
+  ChevronUp,
+} from 'lucide-react';
+import { creatorAgencyApi, PendingInvitation } from '@/lib/agency-api';
+
+export function AgencyInvitationsBanner() {
+  const [invitations, setInvitations] = useState<PendingInvitation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState(false);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadInvitations();
+  }, []);
+
+  const loadInvitations = async () => {
+    try {
+      setLoading(true);
+      const data = await creatorAgencyApi.getInvitations();
+      setInvitations(data);
+    } catch (error) {
+      console.error('Failed to load invitations:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAccept = async (invitationId: string) => {
+    try {
+      setActionLoading(invitationId);
+      await creatorAgencyApi.acceptInvitation(invitationId);
+      // Reload the page to show updated agency status
+      window.location.reload();
+    } catch (error) {
+      console.error('Failed to accept invitation:', error);
+      alert('Failed to accept invitation. Please try again.');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleDecline = async (invitationId: string) => {
+    try {
+      setActionLoading(invitationId);
+      await creatorAgencyApi.declineInvitation(invitationId);
+      setInvitations((prev) => prev.filter((inv) => inv.id !== invitationId));
+    } catch (error) {
+      console.error('Failed to decline invitation:', error);
+      alert('Failed to decline invitation. Please try again.');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  if (loading || invitations.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="glass-panel rounded-2xl border border-holo-teal/30 p-6 shadow-glow-teal backdrop-blur-md">
+      <div
+        className="flex items-center justify-between cursor-pointer"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <div className="flex items-center gap-4">
+          <div className="p-2 rounded-xl bg-gradient-to-br from-holo-teal/20 to-holo-teal-dark/20 border border-holo-teal/30">
+            <Building2 className="h-5 w-5 text-holo-teal" />
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="font-bold text-lg text-holo-teal">Agency Invitations</span>
+              <span className="px-2 py-0.5 text-xs font-semibold rounded-full bg-holo-teal/20 text-holo-teal">
+                {invitations.length}
+              </span>
+            </div>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              You have pending invitations to join agencies
+            </p>
+          </div>
+        </div>
+        <button className="p-2 rounded-lg hover:bg-holo-teal/10 transition-colors">
+          {expanded ? (
+            <ChevronUp className="h-5 w-5 text-holo-teal" />
+          ) : (
+            <ChevronDown className="h-5 w-5 text-holo-teal" />
+          )}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="mt-4 space-y-3">
+          {invitations.map((invitation) => (
+            <div
+              key={invitation.id}
+              className="flex items-center justify-between p-4 rounded-xl bg-background/50 border border-card-border"
+            >
+              <div className="flex items-center gap-3">
+                {invitation.agency_logo_url ? (
+                  <img
+                    src={invitation.agency_logo_url}
+                    alt={invitation.agency_name}
+                    className="w-10 h-10 rounded-lg object-cover"
+                  />
+                ) : (
+                  <div className="w-10 h-10 rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
+                    <Building2 className="h-5 w-5 text-gray-500" />
+                  </div>
+                )}
+                <div>
+                  <p className="font-medium text-foreground">{invitation.agency_name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Expires {formatDate(invitation.expires_at)}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDecline(invitation.id);
+                  }}
+                  disabled={actionLoading === invitation.id}
+                  className="p-2 rounded-lg text-muted-foreground hover:text-rose-500 hover:bg-rose-500/10 transition-colors"
+                  title="Decline"
+                >
+                  {actionLoading === invitation.id ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <X className="h-4 w-4" />
+                  )}
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleAccept(invitation.id);
+                  }}
+                  disabled={actionLoading === invitation.id}
+                  className="px-3 py-1.5 rounded-lg bg-holo-teal text-white text-sm font-medium hover:bg-holo-teal/90 transition-colors flex items-center gap-1"
+                >
+                  {actionLoading === invitation.id ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <>
+                      <Check className="h-4 w-4" />
+                      Accept
+                    </>
+                  )}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/agency/AgencyLayout.tsx
+++ b/frontend/components/agency/AgencyLayout.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import Image from 'next/image';
+import { useAuth } from '@/lib/auth';
+import { ThemeToggle } from '@/components/shared/ThemeToggle';
+import {
+  Building2,
+  Users,
+  Briefcase,
+  Settings,
+  LogOut,
+  LayoutDashboard,
+  UserPlus,
+  ChevronDown,
+  Bell,
+} from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface AgencyLayoutProps {
+  children: React.ReactNode;
+}
+
+const navigation = [
+  { name: 'Dashboard', href: '/agency', icon: LayoutDashboard },
+  { name: 'Creators', href: '/agency/creators', icon: Users },
+  { name: 'Opportunities', href: '/agency/opportunities', icon: Briefcase },
+  { name: 'Team', href: '/agency/team', icon: UserPlus },
+  { name: 'Settings', href: '/agency/settings', icon: Settings },
+];
+
+export function AgencyLayout({ children }: AgencyLayoutProps) {
+  const pathname = usePathname();
+  const { user, logout } = useAuth();
+
+  const isActiveRoute = (href: string) => {
+    if (href === '/agency') {
+      return pathname === '/agency';
+    }
+    return pathname.startsWith(href);
+  };
+
+  return (
+    <div className="min-h-screen section-background">
+      {/* Header */}
+      <header className="fixed top-0 left-0 right-0 z-50 h-16 border-b border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-900/80 backdrop-blur-md">
+        <div className="h-full px-4 sm:px-6 lg:px-8 flex items-center justify-between">
+          {/* Logo & Agency Badge */}
+          <div className="flex items-center gap-4">
+            <Link href="/agency" className="flex items-center gap-2">
+              <Image
+                src="/logo/text_light.png"
+                alt="Repruv"
+                width={120}
+                height={32}
+                className="h-8 w-auto dark:hidden"
+                priority
+              />
+              <Image
+                src="/logo/text_dark.png"
+                alt="Repruv"
+                width={120}
+                height={32}
+                className="h-8 w-auto hidden dark:block"
+                priority
+              />
+            </Link>
+            <div className="hidden sm:flex items-center gap-1.5 px-2.5 py-1 bg-green-50 dark:bg-green-900/20 rounded-full border border-green-200 dark:border-green-800">
+              <Building2 className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
+              <span className="text-xs font-medium text-green-700 dark:text-green-300">
+                Agency
+              </span>
+            </div>
+          </div>
+
+          {/* Navigation */}
+          <nav className="hidden md:flex items-center gap-1">
+            {navigation.map((item) => {
+              const isActive = isActiveRoute(item.href);
+              return (
+                <Link
+                  key={item.name}
+                  href={item.href}
+                  className={cn(
+                    'flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
+                    isActive
+                      ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300'
+                      : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
+                  )}
+                >
+                  <item.icon className="h-4 w-4" />
+                  {item.name}
+                </Link>
+              );
+            })}
+          </nav>
+
+          {/* Right side actions */}
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+
+            {/* Notifications */}
+            <Button variant="ghost" size="icon" className="relative">
+              <Bell className="h-5 w-5" />
+              {/* Notification badge - can be made dynamic */}
+              {/* <span className="absolute -top-1 -right-1 h-4 w-4 bg-red-500 rounded-full text-[10px] text-white flex items-center justify-center font-medium">
+                3
+              </span> */}
+            </Button>
+
+            {/* User menu */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="flex items-center gap-2 px-2"
+                >
+                  <div className="h-8 w-8 rounded-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center text-white font-medium text-sm">
+                    {user?.full_name?.charAt(0) || user?.email?.charAt(0) || 'A'}
+                  </div>
+                  <div className="hidden sm:block text-left">
+                    <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                      {user?.full_name || 'Agency User'}
+                    </div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                      {user?.email}
+                    </div>
+                  </div>
+                  <ChevronDown className="h-4 w-4 text-gray-400" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <div className="px-2 py-1.5">
+                  <p className="text-sm font-medium">{user?.full_name}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">{user?.email}</p>
+                </div>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
+                  <Link href="/agency/settings" className="cursor-pointer">
+                    <Settings className="mr-2 h-4 w-4" />
+                    Settings
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={() => logout()}
+                  className="text-red-600 dark:text-red-400 cursor-pointer"
+                >
+                  <LogOut className="mr-2 h-4 w-4" />
+                  Sign out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+      </header>
+
+      {/* Mobile navigation */}
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 z-50 h-16 border-t border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
+        <div className="h-full grid grid-cols-5">
+          {navigation.map((item) => {
+            const isActive = isActiveRoute(item.href);
+            return (
+              <Link
+                key={item.name}
+                href={item.href}
+                className={cn(
+                  'flex flex-col items-center justify-center gap-1 text-xs font-medium transition-colors',
+                  isActive
+                    ? 'text-green-600 dark:text-green-400'
+                    : 'text-gray-500 dark:text-gray-400'
+                )}
+              >
+                <item.icon className="h-5 w-5" />
+                <span className="truncate max-w-[60px]">{item.name}</span>
+              </Link>
+            );
+          })}
+        </div>
+      </nav>
+
+      {/* Main content */}
+      <main className="pt-16 pb-16 md:pb-0 min-h-screen">
+        <div className="px-4 sm:px-6 lg:px-8 py-6">
+          {children}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/components/agency/index.ts
+++ b/frontend/components/agency/index.ts
@@ -1,0 +1,2 @@
+export { AgencyBadge } from './AgencyBadge';
+export { AgencyInvitationsBanner } from './AgencyInvitationsBanner';

--- a/frontend/components/layout/AgencyBadge.tsx
+++ b/frontend/components/layout/AgencyBadge.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Building2, Briefcase } from 'lucide-react';
+import { useAuth } from '@/lib/auth';
+import { creatorAgencyApi, creatorOpportunityApi, type CreatorAgency, type CreatorOpportunityCounts } from '@/lib/agency-api';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+export function AgencyBadge() {
+  const { user } = useAuth();
+  const [agency, setAgency] = useState<CreatorAgency | null>(null);
+  const [opportunityCounts, setOpportunityCounts] = useState<CreatorOpportunityCounts | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    // Only fetch for creator users (not agency users)
+    if (!user || user.user_kind === 'agency') {
+      setIsLoading(false);
+      return;
+    }
+
+    const fetchAgencyData = async () => {
+      try {
+        const agencyData = await creatorAgencyApi.getMyAgency();
+        setAgency(agencyData);
+
+        // Only fetch opportunity counts if creator is linked to an agency
+        if (agencyData) {
+          const counts = await creatorOpportunityApi.getCounts();
+          setOpportunityCounts(counts);
+        }
+      } catch (error) {
+        // Creator not linked to an agency - this is expected
+        console.debug('Creator not linked to agency or error fetching:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchAgencyData();
+  }, [user]);
+
+  // Don't render anything for agency users or while loading
+  if (isLoading || !agency || user?.user_kind === 'agency') {
+    return null;
+  }
+
+  const pendingCount = opportunityCounts?.pending || 0;
+
+  return (
+    <TooltipProvider>
+      <div className="hidden md:flex items-center gap-2">
+        {/* Agency Badge */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Link
+              href="/dashboard/opportunities"
+              className="flex items-center gap-2 text-xs font-semibold px-3 py-1.5 rounded-pill glass-panel border border-border backdrop-blur-md hover:border-purple-300 transition-all group"
+            >
+              <Building2 className="h-3.5 w-3.5 text-purple-500" />
+              <span className="text-muted-foreground group-hover:text-foreground transition-colors">
+                {agency.agency_name}
+              </span>
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>You&apos;re managed by {agency.agency_name}</p>
+          </TooltipContent>
+        </Tooltip>
+
+        {/* Pending Opportunities Badge */}
+        {pendingCount > 0 && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Link
+                href="/dashboard/opportunities"
+                className="relative flex items-center gap-1.5 text-xs font-semibold px-2.5 py-1.5 rounded-pill bg-gradient-to-r from-purple-500 to-purple-600 text-white hover:from-purple-600 hover:to-purple-700 transition-all shadow-sm hover:shadow-md"
+              >
+                <Briefcase className="h-3.5 w-3.5" />
+                <span>{pendingCount}</span>
+                {/* Pulse indicator */}
+                <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-orange-400 animate-pulse"></span>
+              </Link>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{pendingCount} pending opportunit{pendingCount === 1 ? 'y' : 'ies'} from your agency</p>
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/frontend/components/layout/Header.tsx
+++ b/frontend/components/layout/Header.tsx
@@ -5,7 +5,7 @@ import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Menu, BarChart3, Brain, ChartPie, Settings as SettingsIcon, MessageSquare, Zap, Radio, Sparkles, DollarSign } from 'lucide-react';
+import { Menu, BarChart3, Brain, ChartPie, Settings as SettingsIcon, MessageSquare, Zap, Radio, Sparkles, DollarSign, Briefcase } from 'lucide-react';
 import { PauseCircle, PlayCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
@@ -24,6 +24,7 @@ import { useRouter } from 'next/navigation';
 import { ThemeToggle } from '@/components/shared/ThemeToggle';
 import { useStore } from '@/lib/store';
 import { features } from '@/lib/features';
+import { AgencyBadge } from './AgencyBadge';
 
 interface HeaderProps {
   onMenuClick: () => void;
@@ -33,6 +34,7 @@ const navigation = [
   { name: 'Dashboard', href: '/dashboard', icon: BarChart3 },
   { name: 'Interactions', href: '/interactions', icon: MessageSquare },
   { name: 'Insights', href: '/insights', icon: Sparkles },
+  { name: 'Opportunities', href: '/dashboard/opportunities', icon: Briefcase },
   { name: 'Monetization', href: '/monetization', icon: DollarSign },
   { name: 'AI Assistant', href: '/ai-assistant', icon: Brain },
   { name: 'Settings', href: '/settings', icon: SettingsIcon },
@@ -240,6 +242,9 @@ export function Header({ onMenuClick }: HeaderProps) {
           </div>
 
           <div className="flex items-center space-x-4">
+            {/* Agency badge for creators */}
+            <AgencyBadge />
+
             {/* Emergency controls & global toggles (conditional) */}
             {features.showEmergencyControls && (
               <div className="hidden md:flex items-center gap-3 mr-3">

--- a/frontend/lib/agency-api.ts
+++ b/frontend/lib/agency-api.ts
@@ -1,0 +1,446 @@
+import { api } from './api';
+
+// Types
+export interface Agency {
+  id: string;
+  name: string;
+  slug: string;
+  owner_id: string;
+  logo_url: string | null;
+  website: string | null;
+  description: string | null;
+  settings: Record<string, unknown>;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AgencyPublic {
+  id: string;
+  name: string;
+  slug: string;
+  logo_url: string | null;
+  description: string | null;
+  website: string | null;
+}
+
+export interface AgencyCreator {
+  id: string;
+  email: string;
+  full_name: string | null;
+  created_at: string;
+  last_login_at: string | null;
+}
+
+export interface AgencyMember {
+  id: string;
+  user_id: string;
+  role: 'owner' | 'admin' | 'member';
+  status: 'pending_invite' | 'pending_request' | 'active' | 'removed';
+  user_email: string;
+  user_full_name: string | null;
+  joined_at: string | null;
+}
+
+export interface AgencyInvitation {
+  id: string;
+  email: string;
+  status: 'pending' | 'accepted' | 'expired' | 'cancelled';
+  expires_at: string;
+  created_at: string;
+}
+
+export interface AgencyStats {
+  creator_count: number;
+  team_member_count: number;
+  pending_invitations: number;
+  pending_join_requests: number;
+  total_reach: number;
+  active_opportunities: number;
+  // Aliases for frontend convenience
+  total_creators?: number;
+  team_members?: number;
+}
+
+export interface CreatorAgency {
+  agency_id: string;
+  agency_name: string;
+  agency_slug: string;
+  agency_logo_url: string | null;
+  role: 'owner' | 'admin' | 'member';
+  joined_at: string | null;
+}
+
+export interface PendingInvitation {
+  id: string;
+  agency_id: string;
+  agency_name: string;
+  agency_logo_url: string | null;
+  invited_at: string;
+  expires_at: string;
+}
+
+// Agency API (for agency users)
+export const agencyApi = {
+  // Get current agency
+  getMyAgency: async (): Promise<Agency> => {
+    const response = await api.get('/agency/me');
+    return response.data;
+  },
+
+  // Update agency
+  updateAgency: async (updates: Partial<Pick<Agency, 'name' | 'logo_url' | 'website' | 'description'>>): Promise<Agency> => {
+    const response = await api.patch('/agency/me', updates);
+    return response.data;
+  },
+
+  // Get agency stats
+  getStats: async (): Promise<AgencyStats> => {
+    const response = await api.get('/agency/stats');
+    return response.data;
+  },
+
+  // Creator management
+  getCreators: async (): Promise<AgencyCreator[]> => {
+    const response = await api.get('/agency/creators');
+    return response.data;
+  },
+
+  removeCreator: async (creatorId: string): Promise<void> => {
+    await api.delete(`/agency/creators/${creatorId}`);
+  },
+
+  // Invitations
+  inviteCreator: async (email: string): Promise<void> => {
+    await api.post('/agency/invitations', { email, role: 'member' });
+  },
+
+  getInvitations: async (status?: string): Promise<AgencyInvitation[]> => {
+    const params = status ? { status } : {};
+    const response = await api.get('/agency/invitations', { params });
+    return response.data;
+  },
+
+  cancelInvitation: async (invitationId: string): Promise<void> => {
+    await api.delete(`/agency/invitations/${invitationId}`);
+  },
+
+  // Join requests
+  getJoinRequests: async (): Promise<AgencyMember[]> => {
+    const response = await api.get('/agency/join-requests');
+    return response.data;
+  },
+
+  acceptJoinRequest: async (requestId: string): Promise<void> => {
+    await api.post(`/agency/join-requests/${requestId}/accept`);
+  },
+
+  rejectJoinRequest: async (requestId: string): Promise<void> => {
+    await api.post(`/agency/join-requests/${requestId}/reject`);
+  },
+
+  // Team management
+  getTeamMembers: async (): Promise<AgencyMember[]> => {
+    const response = await api.get('/agency/team');
+    return response.data;
+  },
+
+  inviteTeamMember: async (email: string, role: 'admin' | 'member'): Promise<void> => {
+    await api.post('/agency/team/invite', { email, role });
+  },
+
+  updateTeamMemberRole: async (memberId: string, role: 'admin' | 'member'): Promise<void> => {
+    await api.patch(`/agency/team/${memberId}/role`, { role });
+  },
+
+  removeTeamMember: async (memberId: string): Promise<void> => {
+    await api.delete(`/agency/team/${memberId}`);
+  },
+
+  // Search agencies
+  searchAgencies: async (query: string, limit = 10): Promise<AgencyPublic[]> => {
+    const response = await api.get('/agency/search', { params: { q: query, limit } });
+    return response.data;
+  },
+};
+
+// Creator Agency API (for creator users)
+export const creatorAgencyApi = {
+  // Get creator's current agency
+  getMyAgency: async (): Promise<CreatorAgency | null> => {
+    const response = await api.get('/creator/agency/current');
+    return response.data;
+  },
+
+  // Leave agency
+  leaveAgency: async (): Promise<void> => {
+    await api.delete('/creator/agency/leave');
+  },
+
+  // Get pending invitations
+  getInvitations: async (): Promise<PendingInvitation[]> => {
+    const response = await api.get('/creator/agency/invitations');
+    return response.data;
+  },
+
+  // Accept invitation
+  acceptInvitation: async (invitationId: string): Promise<{ status: string; agency_id: string }> => {
+    const response = await api.post(`/creator/agency/invitations/${invitationId}/accept`);
+    return response.data;
+  },
+
+  // Decline invitation
+  declineInvitation: async (invitationId: string): Promise<void> => {
+    await api.post(`/creator/agency/invitations/${invitationId}/decline`);
+  },
+
+  // Get pending join requests
+  getJoinRequests: async (): Promise<Array<{
+    id: string;
+    agency_id: string;
+    agency_name: string;
+    agency_logo_url: string | null;
+    requested_at: string;
+  }>> => {
+    const response = await api.get('/creator/agency/join-requests');
+    return response.data;
+  },
+
+  // Request to join agency
+  requestToJoin: async (agencyId: string, message?: string): Promise<{ message: string }> => {
+    const response = await api.post(`/creator/agency/join/${agencyId}`, { message });
+    return response.data;
+  },
+
+  // Cancel join request
+  cancelJoinRequest: async (requestId: string): Promise<void> => {
+    await api.delete(`/creator/agency/join-requests/${requestId}`);
+  },
+
+  // Search agencies
+  searchAgencies: async (query: string, limit = 10): Promise<AgencyPublic[]> => {
+    const response = await api.get('/creator/agency/search', { params: { q: query, limit } });
+    return response.data;
+  },
+};
+
+// Opportunity Types
+export type OpportunityStatus = 'draft' | 'sent' | 'viewed' | 'accepted' | 'declined' | 'completed' | 'cancelled';
+
+export interface OpportunityRequirements {
+  deliverables: string[];
+  content_guidelines?: string;
+  talking_points: string[];
+  restrictions: string[];
+}
+
+export interface OpportunityCompensation {
+  type: 'flat_fee' | 'cpm' | 'hybrid' | 'product_only';
+  amount?: number;
+  currency: string;
+  payment_terms?: string;
+  product_value?: number;
+  notes?: string;
+}
+
+export interface AgencyOpportunity {
+  id: string;
+  agency_id: string;
+  creator_id: string;
+  created_by: string;
+  title: string;
+  brand_name: string;
+  brand_logo_url: string | null;
+  description: string;
+  requirements: OpportunityRequirements;
+  compensation: OpportunityCompensation;
+  deadline: string | null;
+  content_deadline: string | null;
+  status: OpportunityStatus;
+  sent_at: string | null;
+  viewed_at: string | null;
+  creator_response_at: string | null;
+  creator_notes: string | null;
+  project_id: string | null;
+  created_at: string;
+  updated_at: string;
+  creator_email?: string;
+  creator_full_name?: string;
+}
+
+export interface AgencyOpportunityListItem {
+  id: string;
+  creator_id: string;
+  title: string;
+  brand_name: string;
+  status: OpportunityStatus;
+  deadline: string | null;
+  sent_at: string | null;
+  creator_full_name: string | null;
+  created_at: string;
+}
+
+export interface CreateOpportunityData {
+  creator_id: string;
+  title: string;
+  brand_name: string;
+  brand_logo_url?: string;
+  description: string;
+  requirements?: Partial<OpportunityRequirements>;
+  compensation?: Partial<OpportunityCompensation>;
+  deadline?: string;
+  content_deadline?: string;
+}
+
+export interface OpportunityStats {
+  total: number;
+  draft: number;
+  pending: number;
+  accepted: number;
+  declined: number;
+  completed: number;
+  active: number;
+}
+
+// Opportunity API (for agency users)
+export const opportunityApi = {
+  // List opportunities
+  list: async (params?: {
+    status?: OpportunityStatus;
+    creator_id?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<AgencyOpportunityListItem[]> => {
+    const response = await api.get('/agency/opportunities', { params });
+    return response.data;
+  },
+
+  // Get single opportunity
+  get: async (id: string): Promise<AgencyOpportunity> => {
+    const response = await api.get(`/agency/opportunities/${id}`);
+    return response.data;
+  },
+
+  // Create opportunity
+  create: async (data: CreateOpportunityData): Promise<AgencyOpportunity> => {
+    const response = await api.post('/agency/opportunities', data);
+    return response.data;
+  },
+
+  // Update opportunity
+  update: async (id: string, data: Partial<CreateOpportunityData>): Promise<AgencyOpportunity> => {
+    const response = await api.patch(`/agency/opportunities/${id}`, data);
+    return response.data;
+  },
+
+  // Delete draft opportunity
+  delete: async (id: string): Promise<void> => {
+    await api.delete(`/agency/opportunities/${id}`);
+  },
+
+  // Send opportunity to creator
+  send: async (id: string): Promise<AgencyOpportunity> => {
+    const response = await api.post(`/agency/opportunities/${id}/send`);
+    return response.data;
+  },
+
+  // Cancel opportunity
+  cancel: async (id: string): Promise<AgencyOpportunity> => {
+    const response = await api.post(`/agency/opportunities/${id}/cancel`);
+    return response.data;
+  },
+
+  // Mark as completed
+  complete: async (id: string): Promise<AgencyOpportunity> => {
+    const response = await api.post(`/agency/opportunities/${id}/complete`);
+    return response.data;
+  },
+
+  // Get stats
+  getStats: async (): Promise<OpportunityStats> => {
+    const response = await api.get('/agency/opportunities/stats');
+    return response.data;
+  },
+};
+
+// Creator Opportunity Types
+export interface CreatorOpportunity {
+  id: string;
+  agency_id: string;
+  agency_name: string;
+  agency_logo_url: string | null;
+  title: string;
+  brand_name: string;
+  brand_logo_url: string | null;
+  description: string;
+  requirements: OpportunityRequirements;
+  compensation: OpportunityCompensation;
+  deadline: string | null;
+  content_deadline: string | null;
+  status: OpportunityStatus;
+  sent_at: string | null;
+  viewed_at: string | null;
+  project_id: string | null;
+  created_at: string;
+}
+
+export interface CreatorOpportunityListItem {
+  id: string;
+  agency_name: string;
+  title: string;
+  brand_name: string;
+  status: OpportunityStatus;
+  deadline: string | null;
+  sent_at: string | null;
+}
+
+export interface CreatorOpportunityCounts {
+  pending: number;
+  accepted: number;
+  declined: number;
+  completed: number;
+  total: number;
+}
+
+// Creator Opportunity API (for creator users)
+export const creatorOpportunityApi = {
+  // List all opportunities for creator
+  list: async (params?: {
+    status?: OpportunityStatus;
+    limit?: number;
+    offset?: number;
+  }): Promise<CreatorOpportunityListItem[]> => {
+    const response = await api.get('/creator/opportunities', { params });
+    return response.data;
+  },
+
+  // List pending opportunities
+  listPending: async (): Promise<CreatorOpportunityListItem[]> => {
+    const response = await api.get('/creator/opportunities/pending');
+    return response.data;
+  },
+
+  // Get opportunity counts
+  getCounts: async (): Promise<CreatorOpportunityCounts> => {
+    const response = await api.get('/creator/opportunities/count');
+    return response.data;
+  },
+
+  // Get single opportunity
+  get: async (id: string): Promise<CreatorOpportunity> => {
+    const response = await api.get(`/creator/opportunities/${id}`);
+    return response.data;
+  },
+
+  // Accept opportunity
+  accept: async (id: string, notes?: string): Promise<{ message: string; project_id: string | null }> => {
+    const response = await api.post(`/creator/opportunities/${id}/accept`, notes ? { notes } : {});
+    return response.data;
+  },
+
+  // Decline opportunity
+  decline: async (id: string, reason?: string): Promise<{ message: string }> => {
+    const response = await api.post(`/creator/opportunities/${id}/decline`, reason ? { reason } : {});
+    return response.data;
+  },
+};

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -281,6 +281,10 @@ export const useAuth = create<AuthState>((set, get) => ({
       }
       
       if (user.approval_status === 'approved') {
+        // Agency users go to agency dashboard
+        if (user.account_type === 'agency') {
+          return '/agency';
+        }
         return '/dashboard';
       }
     }


### PR DESCRIPTION
- Add agency signup flow with dedicated registration page
- Create agency dashboard with stats, creators, team, and opportunities management
- Implement creator invitation system (invite by email, join requests)
- Build sponsorship opportunity workflow (create, send, accept/decline, complete)
- Add agency badge to creator dashboard header showing linked agency
- Create opportunity pages for both agency and creator sides
- Add email notification tasks for invitations and opportunity updates
- Include database migration for agency tables (agency, agency_member, agency_invitation, agency_opportunity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)