### PR TITLE
Run database migrations on container startup

### DIFF
--- a/backend/app/api/v1/endpoints/agency_notifications.py
+++ b/backend/app/api/v1/endpoints/agency_notifications.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from app.core.database import get_async_session
-from app.core.auth import get_current_user
+from app.core.security import get_current_user
 from app.models.user import User
 from app.models.agency import Agency, AgencyMember
 from app.models.agency_notification import AgencyNotification

--- a/backend/app/api/v1/endpoints/notifications.py
+++ b/backend/app/api/v1/endpoints/notifications.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_async_session
-from app.core.auth import get_current_user
+from app.core.security import get_current_user
 from app.models.user import User
 from app.models.notification import (
     CreatorNotification,


### PR DESCRIPTION
The notifications.py and agency_notifications.py files were importing get_current_user from app.core.auth which does not exist. The function is actually defined in app.core.security. This fixes the ModuleNotFoundError that was preventing the application from starting.